### PR TITLE
Include protect_from_forgery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,9 +92,6 @@ gem 'virtus'
 # CORS
 gem 'rack-cors'
 
-# CSRF
-gem 'angular_rails_csrf', '~> 1.0.3' # XSRF-TOKEN is added to the cookie by default.
-
 # CRONTAB SCHEDULER
 gem 'whenever'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,6 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
-    angular_rails_csrf (1.0.3)
-      rails (>= 3, < 5)
     annotate (2.6.5)
       activerecord (>= 2.3.0)
       rake (>= 0.8.7)
@@ -265,7 +263,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.8.0)
-  angular_rails_csrf (~> 1.0.3)
   annotate
   apipie-rails (~> 0.2.6)
   bcrypt (~> 3.1.7)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,9 @@ class ApplicationController < ActionController::Base
   # Add Token Authentication
   include TokenAuthentication
 
+  protect_from_forgery
+  skip_before_action :verify_authenticity_token, if: :json_request?
+
   def current_user
     current_staff
   end
@@ -36,7 +39,14 @@ class ApplicationController < ActionController::Base
     staff_session
   end
 
+  # Used by ActiveModelSerializers
   def default_serializer_options
     { root: false }
+  end
+
+  private
+
+  def json_request?
+    request.format.json?
   end
 end


### PR DESCRIPTION
- Remove the csrf gem. It does nothing for api. UX and other clients will not be running on the same domain (or port) as API.
- Skip csrf check if the request is a json request (APIs primary communication method)

#275 