### PR TITLE
Added troubleshooting steps used to install api on windows 7

### DIFF
--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -173,42 +173,68 @@ rake upkeep:poll_miq_vms
 rake jobs:work
 ````
 
-###Troubleshooting Tips for Windows Instillation Errors
+### Troubleshooting Tips for Windows Instillation Errors
 The following commands below are known to cause install issues on some windows machines, please see troubleshooting
 steps below each listed command on how to resolve the issues
 
 ####gem install bundler
-If you experience an error of ruby and gemfile mismatch during this step:
-````
-first line of "Gemfile", change ruby version to - ruby '2.1.5'
-run gem install bundler
-````
+If you experience an error of ruby and Gemfile mismatch during this step:
+1. modify the ruby version of the Gemfile to match the version of ruby you have installed, in this case 2.1.5
+ ```
+ ruby '2.1.5'
+ ```
+2. rerun the bundler install
+```
+ gem install bundler
+```
+
 ####bundle install
 If you experience an error, particularly when installing the puma gem on this step complete the following:
 OpenSSL Package[link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
-DevKit? [link](http://rubyinstaller.org/downloads/):
-````
-install DevKit compatible with your ruby version, e.g. in c:\devkit
-unpack the OpenSSL Package, e.g. in c:\openssl
-copy the following dlls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
-open a windows console and initialize the DevKit build environment c:\devkit\devkitvars.bat
-run gem install puma -- --with-opt-dir=c:\openssl to install the puma gem with the OpenSSL packages
-run bundle install
-````
+DevKit [link](http://rubyinstaller.org/downloads/):
+
+1. install DevKit compatible with your ruby version, e.g. in c:\devkit
+2. unpack the OpenSSL Package, e.g. in c:\openssl
+3. copy libeay32.dll and ssleay32.dll, from the DevKit bin directory to the ruby/bin directory
+4. initialize the DevKit build environment from the cli
+```
+c:\devkit\devkitvars.bat
+```
+5. run the following command to install the puma gem with the OpenSSL packages
+```
+gem install puma -- --with-opt-dir=c:\openssl
+```
+6. run
+```
+bundle install
+```
 Additional information on this process can be found here:
 [link](https://github.com/hicknhack-software/rails-disco/wiki/Installing-puma-on-windows)
 
 ####rake db:setup
-If you experience the PG pg_xxt load error when running this command:
-````
+If you experience the PG pg_xxt load error when running rake db:setup :
+
+1. uninstall existing pg gem
+```
 gem uninstall pg
-in the Gemfile identify the pg gem and update the version to:  gem 'pg', '~> 0.18.1'
-in the Gemfile add:  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-run gem update
-run rake db:setup
-````
+```
+2. update the pg gem version in the gem file
+```
+gem 'pg', '~> 0.18.1'
+```
+3. add the tzinfo-data gem to the gemfile
+```
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+```
+4. update all gems
+```
+ gem update
+ ```
+5. rerun rake db:setup
+```
+ rake db:setup
+```
 Additional information on this process can be found here:
 [link](http://stackoverflow.com/questions/26617779/pg-pg-ext-load-error-in-rails)
-
 
 Copyright 2015 Booz Allen Hamilton

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -174,33 +174,40 @@ rake jobs:work
 ````
 
 #### Troubleshooting Tips for Windows Instillation Errors
-The following commands are known to cause install issues on some windows machines, please see troubleshooting steps below the listed command should you encounter issues while installing
+The following commands below are known to cause install issues on some windows machines, please see troubleshooting
+steps below each listed command on how to resolve the issues
 
 #gem install bundler
 If you experience an error of ruby and gemfile mismatch during this step:
-    $ first line of "Gemfile", change ruby version to - ruby '2.1.5'
-    $ run gem install bundler
-
+````
+first line of "Gemfile", change ruby version to - ruby '2.1.5'
+run gem install bundler
+````
 #bundle install
-If you experience an error, particularlly when installing the puma gem on this step complete the following: 
-    $ install DevKit compatible with your ruby version, e.g. in c:\devkit
-    $ unpack the OpenSSL Package, e.g. in c:\openssl (use 7Zip or PeaZip) found here [link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
-    $ copy the following ddls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
-    $ open a windows console and initialize the DevKit build environment c:\devkit\devkitvars.bat
-    $ run gem install puma -- --with-opt-dir=c:\openssl to install the puma gem with the OpenSSL packages
-    $ run bundle install
-    
-Additional information on this process can be found here [link](https://github.com/hicknhack-software/rails-disco/wiki/Installing-puma-on-windows)
+If you experience an error, particularly when installing the puma gem on this step complete the following:
+````
+install DevKit compatible with your ruby version, e.g. in c:\devkit
+unpack the OpenSSL Package, e.g. in c:\openssl (use 7Zip or PeaZip) found here:
+[link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
+copy the following ddls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
+open a windows console and initialize the DevKit build environment c:\devkit\devkitvars.bat
+run gem install puma -- --with-opt-dir=c:\openssl to install the puma gem with the OpenSSL packages
+run bundle install
+````
+Additional information on this process can be found here:
+[link](https://github.com/hicknhack-software/rails-disco/wiki/Installing-puma-on-windows)
 
 #rake db:setup
-If you experience the error PG pg_xxt load error when running this command
-    $ gem uninstall pg
-    $ in the Gemfile idenfity the pg gem and update the version to:  gem 'pg', '~> 0.18.1'
-    $ in the Gemfile add:  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-    $ run gem update
-    $ run rake db:setup
-
-Additional information on this process can be found here [link](http://stackoverflow.com/questions/26617779/pg-pg-ext-load-error-in-rails)
+If you experience the PG pg_xxt load error when running this command:
+````
+gem uninstall pg
+in the Gemfile identify the pg gem and update the version to:  gem 'pg', '~> 0.18.1'
+in the Gemfile add:  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+run gem update
+run rake db:setup
+````
+Additional information on this process can be found here:
+[link](http://stackoverflow.com/questions/26617779/pg-pg-ext-load-error-in-rails)
 
 
 Copyright 2015 Booz Allen Hamilton

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -173,23 +173,24 @@ rake upkeep:poll_miq_vms
 rake jobs:work
 ````
 
-#### Troubleshooting Tips for Windows Instillation Errors
+###Troubleshooting Tips for Windows Instillation Errors
 The following commands below are known to cause install issues on some windows machines, please see troubleshooting
 steps below each listed command on how to resolve the issues
 
-#gem install bundler
+####gem install bundler
 If you experience an error of ruby and gemfile mismatch during this step:
 ````
 first line of "Gemfile", change ruby version to - ruby '2.1.5'
 run gem install bundler
 ````
-#bundle install
+####bundle install
 If you experience an error, particularly when installing the puma gem on this step complete the following:
+OpenSSL Package[link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
+DevKit? [link](http://rubyinstaller.org/downloads/):
 ````
 install DevKit compatible with your ruby version, e.g. in c:\devkit
-unpack the OpenSSL Package, e.g. in c:\openssl (use 7Zip or PeaZip) found here:
-[link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
-copy the following ddls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
+unpack the OpenSSL Package, e.g. in c:\openssl
+copy the following dlls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
 open a windows console and initialize the DevKit build environment c:\devkit\devkitvars.bat
 run gem install puma -- --with-opt-dir=c:\openssl to install the puma gem with the OpenSSL packages
 run bundle install
@@ -197,7 +198,7 @@ run bundle install
 Additional information on this process can be found here:
 [link](https://github.com/hicknhack-software/rails-disco/wiki/Installing-puma-on-windows)
 
-#rake db:setup
+####rake db:setup
 If you experience the PG pg_xxt load error when running this command:
 ````
 gem uninstall pg

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -173,5 +173,34 @@ rake upkeep:poll_miq_vms
 rake jobs:work
 ````
 
+#### Troubleshooting Tips for Windows Instillation Errors
+The following commands are known to cause install issues on some windows machines, please see troubleshooting steps below the listed command should you encounter issues while installing
+
+#gem install bundler
+If you experience an error of ruby and gemfile mismatch during this step:
+    $ first line of "Gemfile", change ruby version to - ruby '2.1.5'
+    $ run gem install bundler
+
+#bundle install
+If you experience an error, particularlly when installing the puma gem on this step complete the following: 
+    $ install DevKit compatible with your ruby version, e.g. in c:\devkit
+    $ unpack the OpenSSL Package, e.g. in c:\openssl (use 7Zip or PeaZip) found here [link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
+    $ copy the following ddls, libeay32.dll and ssleay32.dll, from the DevKit bin directory to your ruby/bin directory
+    $ open a windows console and initialize the DevKit build environment c:\devkit\devkitvars.bat
+    $ run gem install puma -- --with-opt-dir=c:\openssl to install the puma gem with the OpenSSL packages
+    $ run bundle install
+    
+Additional information on this process can be found here [link](https://github.com/hicknhack-software/rails-disco/wiki/Installing-puma-on-windows)
+
+#rake db:setup
+If you experience the error PG pg_xxt load error when running this command
+    $ gem uninstall pg
+    $ in the Gemfile idenfity the pg gem and update the version to:  gem 'pg', '~> 0.18.1'
+    $ in the Gemfile add:  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+    $ run gem update
+    $ run rake db:setup
+
+Additional information on this process can be found here [link](http://stackoverflow.com/questions/26617779/pg-pg-ext-load-error-in-rails)
+
 
 Copyright 2015 Booz Allen Hamilton

--- a/INSTALL-WINDOWS.md
+++ b/INSTALL-WINDOWS.md
@@ -179,32 +179,35 @@ steps below each listed command on how to resolve the issues
 
 ####gem install bundler
 If you experience an error of ruby and Gemfile mismatch during this step:
-1. modify the ruby version of the Gemfile to match the version of ruby you have installed, in this case 2.1.5
+
+modify the ruby version of the Gemfile to match the version of ruby you have installed, in this case 2.1.5
  ```
  ruby '2.1.5'
  ```
-2. rerun the bundler install
+rerun the bundler install
 ```
  gem install bundler
 ```
 
 ####bundle install
 If you experience an error, particularly when installing the puma gem on this step complete the following:
+
 OpenSSL Package[link](http://packages.openknapsack.org/openssl/openssl-1.0.0o-x86-windows.tar.lzma)
+
 DevKit [link](http://rubyinstaller.org/downloads/):
 
-1. install DevKit compatible with your ruby version, e.g. in c:\devkit
-2. unpack the OpenSSL Package, e.g. in c:\openssl
-3. copy libeay32.dll and ssleay32.dll, from the DevKit bin directory to the ruby/bin directory
-4. initialize the DevKit build environment from the cli
+install DevKit compatible with your ruby version, e.g. in c:\devkit
+unpack the OpenSSL Package, e.g. in c:\openssl
+copy libeay32.dll and ssleay32.dll, from the DevKit bin directory to the ruby/bin directory
+initialize the DevKit build environment from the cli
 ```
 c:\devkit\devkitvars.bat
 ```
-5. run the following command to install the puma gem with the OpenSSL packages
+run the following command to install the puma gem with the OpenSSL packages
 ```
 gem install puma -- --with-opt-dir=c:\openssl
 ```
-6. run
+run
 ```
 bundle install
 ```
@@ -214,23 +217,23 @@ Additional information on this process can be found here:
 ####rake db:setup
 If you experience the PG pg_xxt load error when running rake db:setup :
 
-1. uninstall existing pg gem
+uninstall existing pg gem
 ```
 gem uninstall pg
 ```
-2. update the pg gem version in the gem file
+update the pg gem version in the gem file
 ```
 gem 'pg', '~> 0.18.1'
 ```
-3. add the tzinfo-data gem to the gemfile
+add the tzinfo-data gem to the gemfile
 ```
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 ```
-4. update all gems
+update all gems
 ```
  gem update
  ```
-5. rerun rake db:setup
+rerun rake db:setup
 ```
  rake db:setup
 ```


### PR DESCRIPTION
Troubleshooting steps ask user to modify the Gemfile, I realize this might be a no no, but within are the three points of contention I encountered when installing on an x64 windows 7 machine. 

It should also be mentioned I choose the route of rails installer toboot.