### PR TITLE
Feature/add hooks system

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -1,6 +1,8 @@
 class AlertsController < ApplicationController
   after_action :verify_authorized
+  after_action :post_hook
 
+  before_action :pre_hook
   before_action :load_alerts, only: [:index]
   before_action :load_alert, only: [:show, :edit, :update, :destroy]
   before_action :load_update_params, only: [:update]
@@ -177,5 +179,13 @@ class AlertsController < ApplicationController
       order_item_id: @alert_params['order_item_id']
     }
     Alert.where(conditions).order('updated_at DESC').limit(1).first
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/manage_iq_products_controller.rb
+++ b/app/controllers/manage_iq_products_controller.rb
@@ -1,6 +1,8 @@
 class ManageIqProductsController < ApplicationController
   after_action :verify_authorized
+  after_action :post_hook
 
+  before_action :pre_hook
   before_action :load_manage_iq_product_params, only: [:create, :update]
   before_action :load_manage_iq_product, only: [:update]
 
@@ -82,5 +84,13 @@ class ManageIqProductsController < ApplicationController
 
   def load_manage_iq_product
     @manage_iq_product = ManageIqProduct.find(params.require(:id))
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,8 @@
 class ProductsController < ApplicationController
   after_action :verify_authorized
+  after_action :post_hook
 
+  before_action :pre_hook
   before_action :load_product, only: [:show, :update, :destroy]
   before_action :load_products, only: [:index]
   before_action :load_answers, only: [:answers]
@@ -57,5 +59,13 @@ class ProductsController < ApplicationController
   def load_answers
     load_product
     @answers = @product.answers
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/project_approvals_controller.rb
+++ b/app/controllers/project_approvals_controller.rb
@@ -1,4 +1,7 @@
 class ProjectApprovalsController < ApplicationController
+  before_action :pre_hook
+  after_action :post_hook
+
   api :GET, '/projects/:project_id/approvals', 'Returns a list of all approvals for a project'
   param :project_id, :number, required: true
 
@@ -37,5 +40,13 @@ class ProjectApprovalsController < ApplicationController
 
   def project
     @_project ||= Project.find(params[:project_id]).tap { |proj| authorize(proj) }
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/project_staff_controller.rb
+++ b/app/controllers/project_staff_controller.rb
@@ -1,4 +1,7 @@
 class ProjectStaffController < ApplicationController
+  before_action :pre_hook
+  after_action :post_hook
+
   api :GET, '/projects/:project_id/staff', 'Shows collection of staff for a :project_id'
   param :project_id, :number, required: true
   error code: 404, desc: MissingRecordDetection::Messages.not_found
@@ -37,5 +40,13 @@ class ProjectStaffController < ApplicationController
 
   def project
     @_project ||= Project.find(params[:project_id]).tap { |proj| authorize(proj) }
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,9 @@
 class ProjectsController < ApplicationController
   PROJECT_INCLUDES = %w(alerts approvals approvers latest_alerts project_answers project_detail services staff)
   PROJECT_METHODS = %w(account_number cpu domain hdd icon monthly_spend order_history problem_count ram resources resources_unit state state_ok status url users)
+  before_action :pre_hook
   after_action :verify_authorized
+  after_action :post_hook
 
   def self.document_project_params
     with_options required: false do |api|
@@ -104,5 +106,13 @@ class ProjectsController < ApplicationController
 
   def project
     @_project ||= Project.find(params[:id])
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < Devise::SessionsController
 
   skip_before_action :verify_signed_out_user, only: :destroy
   before_action :pre_hook
-  after_action :post_hook # TODO: VERIFY THAT AFTER_ACTION ORDER WON'T BREAK ANYTHING
+  after_action :post_hook
 
   api :POST, '/staff/sign_in', 'Signs user in'
   param :staff, Hash, desc: 'Staff' do

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,8 @@ class SessionsController < Devise::SessionsController
   respond_to :json, :html
 
   skip_before_action :verify_signed_out_user, only: :destroy
+  before_action :pre_hook
+  after_action :post_hook # TODO: VERIFY THAT AFTER_ACTION ORDER WON'T BREAK ANYTHING
 
   api :POST, '/staff/sign_in', 'Signs user in'
   param :staff, Hash, desc: 'Staff' do
@@ -39,5 +41,15 @@ class SessionsController < Devise::SessionsController
         render json: {}, status: :ok
       end
     end
+  end
+
+  private
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end

--- a/app/controllers/staff_controller.rb
+++ b/app/controllers/staff_controller.rb
@@ -1,4 +1,7 @@
 class StaffController < ApplicationController
+  before_action :pre_hook
+  after_action :post_hook
+
   def self.document_staff_params
     param :email, String
     param :first_name, String
@@ -89,5 +92,13 @@ class StaffController < ApplicationController
 
   def staff_params
     params.permit(:first_name, :last_name, :email, :role, :password, :password_confirmation)
+  end
+
+  def pre_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/pre_hook')
+  end
+
+  def post_hook
+    ActiveSupport::Notifications.instrument(controller_name + '#' + action_name + '/post_hook')
   end
 end


### PR DESCRIPTION
Addresses Issue #128.

Adds hooks to the following controllers
- Project_approvals
- Project_staff
- Projects
- Sessions
- Staff
- Manage IQ Products
- Products
- Alerts

For an example of how to use these hooks, see [jellyfish-notice](https://github.com/projectjellyfish/jellyfish-notice). To add subscriptions in API, put them in a file under `config/initializers`.