### PR TITLE
Fix APIPIE documentation on Heroku.

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -4,4 +4,5 @@ Apipie.configure do |config|
   config.doc_base_url            = '/documentation'
   # where is your API defined?
   config.api_controllers_matcher = "#{Rails.root}/app/controllers/*.rb"
+  config.reload_controllers = true
 end


### PR DESCRIPTION
Set config.reload_controllers = true in Apiepie initializer because it doesn't automatically load documentation for each controller in test and production.