### PR TITLE
Feature/return api token json

### DIFF
--- a/app/controllers/concerns/token_authentication.rb
+++ b/app/controllers/concerns/token_authentication.rb
@@ -18,16 +18,8 @@ module TokenAuthentication
   # via parameters. However, anyone could use Rails's token
   # authentication features to get the token from a header.
   def authenticate_staff_from_token!
-    return unless request.headers['X-Staff-Token'].present? && request.headers['X-Staff-Email'].present?
-    # Set the authentication params if not already present
-    params[:user_token] = request.headers['X-Staff-Token']
-    params[:user_email] = request.headers['X-Staff-Email']
-
-    user_email = params[:user_email].presence
-    user = user_email && Staff.find_by(email: user_email)
-
-    return unless user && user.token?(params[:user_token])
-
+    user = Staff.find_by(email: request.headers['X-Staff-Email'], authentication_token: request.headers['X-Staff-Token'])
+    return unless user.present?
     # Notice we are passing store false, so the user is not actually stored in the session and a token is needed for
     # every request. If you want the token to work as a sign in token, you can simply remove store: false.
     sign_in user, store: false

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,7 +21,7 @@ class SessionsController < Devise::SessionsController
 
         if resource
           resource.authentication_token = nil # RESET USER TOKEN AFTER GETTING RESOURCE FROM WARDEN
-          resource.save # THIS FORCES A NEW API TOKEN TO BE GENERATED FOR USER
+          resource.save # THIS FORCES A NEW USER API TOKEN TO BE GENERATED
           sign_in(resource_name, resource)
           resource.api_token = resource.authentication_token
           render json: resource

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,10 +18,10 @@ class SessionsController < Devise::SessionsController
       end
       format.json do
         self.resource = warden.authenticate(auth_options)
-        resource.authentication_token = nil # RESET USER TOKEN AFTER GETTING RESOURCE FROM WARDEN
-        resource.save # THIS FORCES A NEW API TOKEN TO BE GENERATED FOR USER
 
         if resource
+          resource.authentication_token = nil # RESET USER TOKEN AFTER GETTING RESOURCE FROM WARDEN
+          resource.save # THIS FORCES A NEW API TOKEN TO BE GENERATED FOR USER
           sign_in(resource_name, resource)
           resource.api_token = resource.authentication_token
           render json: resource

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,11 +18,12 @@ class SessionsController < Devise::SessionsController
       end
       format.json do
         self.resource = warden.authenticate(auth_options)
+        resource.authentication_token = nil # RESET USER TOKEN AFTER GETTING RESOURCE FROM WARDEN
+        resource.save # THIS FORCES A NEW API TOKEN TO BE GENERATED FOR USER
 
         if resource
           sign_in(resource_name, resource)
-          resource.api_token = resource.secret = SecureRandom.hex
-          resource.save # GENERATE NEW TOKEN FOR USER AND PERSIST IT TO DB
+          resource.api_token = resource.authentication_token
           render json: resource
         else
           render json: { error: 'Invalid Login' }, status: 401


### PR DESCRIPTION
Addresses issue #361, Return mobile token on JSON sign in  
Changes:
 - Modify session controller to reset user authentication token on login and return authentication token as api token.
 - Removed call to token? from TokenAuthentication because it was incorrectly comparing tokens with BCrypt.
