### PR TITLE
Modified the instructions for Clone Repo

### DIFF
--- a/INSTALL-OSX.md
+++ b/INSTALL-OSX.md
@@ -32,7 +32,7 @@ env RCRC=$HOME/dotfiles/rcrc rcup
 #### Clone the Repo
 
 ````
-git clone git@github.com:projectjellyfish/api.git
+git clone https://github.com/projectjellyfish/api.git
 ````
 
 #### Add this data to ./.env


### PR DESCRIPTION
Modified the instructions for Clone Repo. SSH key won't be in GitHub, so give it the public URL instead.