### PR TITLE
Feature/update sensu alerts

### DIFF
--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -4,7 +4,7 @@ class AlertsController < ApplicationController
 
   before_action :pre_hook
   before_action :load_alerts, only: [:index]
-  before_action :load_alert, only: [:show, :edit, :update, :destroy]
+  before_action :load_alert, only: [:show, :update, :destroy]
   before_action :load_update_params, only: [:update]
   before_action :load_create_params, only: [:create]
 

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -13,6 +13,7 @@ class AlertsController < ApplicationController
 
   api :GET, '/alerts', 'Returns all alerts.'
   param :active, :bool, required: false
+  param :latest, :bool, required: false
   param :sort, Array, required: false
   param :not_status, Array, required: false
   param :includes, Array, required: false, in: %w(project)

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -38,7 +38,7 @@ class AlertsController < ApplicationController
   param :host, String, required: true, desc: 'The host of the product associated with this alert.'
   param :port, String, required: true, desc: 'The port of the product associated with this alert.'
   param :service, String, required: true, desc: 'Name of service deployed on host'
-  param :status, String, required: true, desc: 'Status message associated issued with this service from Sense. <br>Current Options: OK, WARNING, CRITICAL, UNKNOWN, PENDING'
+  param :status, String, required: true, desc: 'Status message associated issued with this service from Sensu. <br>Current Options: OK, WARNING, CRITICAL, UNKNOWN, PENDING'
   param :message, String, required: true, desc: 'Actual message content of alert.'
   param :start_date, String, required: false, desc: 'Date this alert will begin appearing. Null indicates the alert will start appearing immediately.'
   param :end_date, String, required: false, desc: 'Date this alert should no longer be displayed after. Null indicates the alert does not expire.'

--- a/app/controllers/alerts_controller.rb
+++ b/app/controllers/alerts_controller.rb
@@ -34,13 +34,14 @@ class AlertsController < ApplicationController
   end
 
   api :POST, '/alerts/sensu', 'Create new Sensu alert.'
-  param :hostname, String, required: true, desc: 'The host of the product associated with this alert.'
+  param :host, String, required: true, desc: 'The host of the product associated with this alert.'
   param :port, String, required: true, desc: 'The port of the product associated with this alert.'
   param :service, String, required: true, desc: 'Name of service deployed on host'
   param :status, String, required: true, desc: 'Status message associated issued with this service from Sense. <br>Current Options: OK, WARNING, CRITICAL, UNKNOWN, PENDING'
   param :message, String, required: true, desc: 'Actual message content of alert.'
-  param :event, String, required: true, desc: 'TBD. Stubbed out for now.'
-  description 'Endpoint to push an alert from Sensu to Core. <br>If an alert already exists for this order, then update that order.'
+  param :start_date, String, required: false, desc: 'Date this alert will begin appearing. Null indicates the alert will start appearing immediately.'
+  param :end_date, String, required: false, desc: 'Date this alert should no longer be displayed after. Null indicates the alert does not expire.'
+  description 'Endpoint to push an alert from Sensu to API. <br>If an alert already exists for this service, then update that service.'
   error code: 422, desc: ParameterValidation::Messages.missing
 
   def sensu

--- a/spec/requests/alert_spec.rb
+++ b/spec/requests/alert_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Alerts API' do
     end
 
     it 'verifies creation of a new sensu alert', :show_in_doc do
-      alert_data = { hostname: 'foo.bar.com', port: '5000', service: 'postgresql', status: 'OK', message: 'This is a test', event: 'tbd' }
+      alert_data = { host: 'foo.bar.com', port: '5000', service: 'postgresql', status: 'OK', message: 'This is a test' }
       post '/api/v1/alerts/sensu', alert_data
       expect(json['message']).to eq(alert_data[:message])
     end


### PR DESCRIPTION
Removes attempts to add attributes to params var, instead populates @alert_params and @alert_id with before_actions and the proceeds accordingly.
To enable 'latest' to be a URL param Alerts could filter on, I needed to reduce the cyclomatic complexity of load_alerts - basically broke out each filter into its own private method.