### PR TITLE
returns monthly projection as order total.

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -47,6 +47,9 @@ class OrderItem < ActiveRecord::Base
   has_many :provision_derivations
   belongs_to :latest_alert, class_name: 'Alert'
 
+  # Update the parent Order total
+  after_create :update_order_total
+
   # Hooks
   after_commit :provision, on: :create
 
@@ -75,5 +78,10 @@ class OrderItem < ActiveRecord::Base
 
   def provision
     provisioner.delay(queue: 'provision_request').provision(id)
+  end
+
+  def update_order_total
+    @orders_params = { total: order.total + calculate_price }
+    order.update @orders_params
   end
 end


### PR DESCRIPTION
adds an `after_create` method to `order_items_controller` which will update parent `order` with the projected monthly cost of each service after the service is created.
projected monthly cost = setup + monthly + hourly * 750