### PR TITLE
Validate Role.permissions format

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -9,6 +9,34 @@
 #
 
 class Role < ActiveRecord::Base
+  PERMISSIONS = %w(projects approvals memberships)
+
   has_many :groups
   has_many :projects, through: :groups
+
+  validate :permissions_format_is_correct, if: :permissions
+
+  def permissions_format_is_correct
+    all_valid_keys
+    all_valid_values
+    no_empty_values
+  end
+
+  def all_valid_keys
+    unless permissions.keys & PERMISSIONS == permissions.keys
+      errors.add(:permissions, "can only include permissions for #{PERMISSIONS.to_sentence}.")
+    end
+  end
+
+  def all_valid_values
+    unless permissions.values.all? { |perms| perms & %w(read write) == perms }
+      errors.add(:permissions, 'can only include "read" and "write" values for each key.')
+    end
+  end
+
+  def no_empty_values
+    unless permissions.values.all?(&:present?)
+      errors.add(:permissions, 'can not contain empty permissions values.')
+    end
+  end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Role do
+  describe 'permissions validation' do
+    it 'is valid for expected permissions schemes' do
+      expect(Role.new(permissions: { 'projects' => %w(read write) })).to be_valid
+      expect(Role.new(permissions: nil)).to be_valid
+      expect(Role.new(permissions: {})).to be_valid
+    end
+
+    it 'adds an error for disallowed models' do
+      role = Role.new(permissions: { 'nope' => %w(read) })
+      expect(role).to be_invalid
+      expect(role.errors[:permissions]).to include("can only include permissions for #{Role::PERMISSIONS.to_sentence}.")
+    end
+
+    it 'adds an error for actions besides read/write' do
+      role = Role.new(permissions: { 'projects' => %w(approve) })
+      expect(role).to be_invalid
+      expect(role.errors[:permissions]).to include('can only include "read" and "write" values for each key.')
+    end
+
+    it 'adds an error for empty actions' do
+      role = Role.new(permissions: { 'projects' => [] })
+      expect(role).to be_invalid
+      expect(role.errors[:permissions]).to include('can not contain empty permissions values.')
+    end
+  end
+end


### PR DESCRIPTION
Since this is a JSONb column and is pretty freeform, we want to ensure
the data we store in the permissions column follows the structure we
expect. Ensure that it contains only valid models and only valid
read/write actions. Also make sure we don't have garbage empty data
stored.