### PR TITLE
Add stack wizard frontend

### DIFF
--- a/app/assets/javascripts/apiRoutes.js
+++ b/app/assets/javascripts/apiRoutes.js
@@ -39,8 +39,8 @@ window.apiRoutes = {
 
     "groups":            "/groups",
     "groupsById":        "/groups/:id",
-
     "roles":             "/roles",
-    "rolesById":         "/roles/:id"
+    "rolesById":         "/roles/:id",
+    "wizardQuestions": "/wizard_questions/:id",
   }
 };

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -35,6 +35,7 @@ angular.module("broker", [
   "broker.users",
   "broker.settings",
   "broker.memberships",
+  "broker.wizard",
   "schemaForm",
   "nvd3",
   "ngDraggable",

--- a/app/assets/javascripts/projects/index.js
+++ b/app/assets/javascripts/projects/index.js
@@ -61,10 +61,11 @@ var ProjectsModule = angular.module('broker.projects', [])
             })
             // Add Service to Project
             .state('base.authed.project.addService', {
-                url: "^/project/:projectId/add-service",
+                url: "^/project/:projectId/add-service?tags",
                 templateUrl: '/templates/partials/projects/add_services.html',
                 controller: 'ProjectServicesController as projectServicesCtrl',
-                resolve: ProjectServicesData
+                resolve: ProjectServicesData,
+                params: { tags: { array: 'true' } },
             });
     }
 );

--- a/app/assets/javascripts/projects/project_controller.js
+++ b/app/assets/javascripts/projects/project_controller.js
@@ -1,10 +1,14 @@
 'use strict';
 
 /**@ngInject*/
-function ProjectController($scope, $interval, $state, project, OrderItemsResource, alerts, products, FlashesService, currentUser) {
+function ProjectController($scope, $interval, $state, project, OrderItemsResource, alerts, products, FlashesService, WizardQuestionsResource, currentUser) {
 
   $scope.intervalDelay = 30000;
   $scope.$interval = $interval;
+  WizardQuestionsResource.query()
+    .$promise.then(function(questions) {
+      $scope.wizardPresent = questions.length > 0
+    });
 
   $scope.project = project;
   this.reason = null; // The reason this project has been rejected.

--- a/app/assets/javascripts/wizards/index.js
+++ b/app/assets/javascripts/wizards/index.js
@@ -1,0 +1,7 @@
+(function () {
+  'use strict';
+
+  angular.module('broker.wizard', [])
+}());
+
+//= require_tree .

--- a/app/assets/javascripts/wizards/multiple_choice_directive.js
+++ b/app/assets/javascripts/wizards/multiple_choice_directive.js
@@ -1,0 +1,25 @@
+(function() {
+  'use strict';
+
+  angular.module('broker.wizard')
+    .directive('multipleChoice', MultipleChoiceDirective)
+
+  function MultipleChoiceDirective() {
+    return {
+      restrict: 'E',
+      templateUrl: '/templates/partials/wizard/multiple_choice.html',
+      link: function(scope) {
+        scope.$watch('model', function(newValue){
+          if(newValue) {
+            scope.action()
+          }
+        })
+      },
+      scope: {
+        action: "=",
+        model: "=",
+        options: "=",
+      }
+    };
+  };
+}());

--- a/app/assets/javascripts/wizards/questions_controller.js
+++ b/app/assets/javascripts/wizards/questions_controller.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  angular.module('broker.wizard')
+    /**@ngInject*/
+    .controller('WizardQuestionsController', function($stateParams, question, questions) {
+      var vm = this;
+
+      vm.nextQuestion = nextQuestion;
+      vm.projectId = $stateParams.projectId;
+      vm.question = question;
+      vm.resetWizard = resetWizard;
+      vm.tags = [];
+
+      function nextQuestion() {
+        vm.tags = _.union(vm.tags, vm.answer.tags_to_add)
+        vm.tags = _.difference(vm.tags, vm.answer.tags_to_remove)
+
+        if(vm.question.next_question_id) {
+          questions.next(vm.question).then(function(question) {
+            vm.question = question;
+          });
+        } else {
+          vm.noMoreQuestions = true;
+        }
+      };
+
+      function resetWizard() {
+        vm.answer = {};
+        vm.question = question;
+        vm.tags = [];
+      };
+    });
+}());

--- a/app/assets/javascripts/wizards/questions_factory.js
+++ b/app/assets/javascripts/wizards/questions_factory.js
@@ -1,0 +1,18 @@
+(function() {
+  'use strict';
+
+  angular.module('broker.wizard')
+    .factory('questions', questions);
+
+  function questions(WizardQuestionsResource) {
+    return {
+      next: next,
+    }
+
+    function next(currentQuestion) {
+      return WizardQuestionsResource
+        .get({ id: currentQuestion.next_question_id })
+        .$promise;
+    }
+  };
+}());

--- a/app/assets/javascripts/wizards/questions_resource.js
+++ b/app/assets/javascripts/wizards/questions_resource.js
@@ -1,0 +1,12 @@
+(function() {
+  'use strict';
+
+  angular.module('broker.wizard')
+    /**@ngInject*/
+    .factory('WizardQuestionsResource', function($resource, apiResource) {
+      return $resource(apiResource('wizardQuestions'), {
+        id: '@id',
+        'includes[]': ['wizard_answers']
+      });
+    });
+}());

--- a/app/assets/javascripts/wizards/state.js
+++ b/app/assets/javascripts/wizards/state.js
@@ -1,0 +1,17 @@
+(function() {
+  angular.module('broker.wizard')
+    .config(function($stateProvider) {
+      $stateProvider
+        .state('base.authed.wizard', {
+          url: "/project/:projectId/wizard",
+          templateUrl: "/templates/partials/wizard/question.html",
+          resolve: {
+            /**@ngInject*/
+            question: function(WizardQuestionsResource) {
+              return WizardQuestionsResource.get({ id: "first" }).$promise;
+            },
+          },
+          controller: "WizardQuestionsController as vm"
+        });
+    });
+}());

--- a/app/controllers/wizard_questions_controller.rb
+++ b/app/controllers/wizard_questions_controller.rb
@@ -1,19 +1,41 @@
 class WizardQuestionsController < ApplicationController
+  api :GET, '/wizard_questions', 'List all wizard questions with answers'
+  param :includes, Array, in: ['wizard_answers']
+
+  def index
+    respond_with_params WizardQuestion.all
+  end
+
+  api :GET, '/wizard_questions/first', 'Return first question'
+  param :includes, Array, in: ['wizard_answers']
+  error code: 404, desc: MissingRecordDetection::Messages.not_found
+
   def first
     respond_with_params WizardQuestion.first
   end
+
+  api :GET, '/wizard_questions/:id', 'Shows question with :id'
+  param :id, :number, required: true
+  param :includes, Array, in: ['wizard_answers']
+  error code: 404, desc: MissingRecordDetection::Messages.not_found
 
   def show
     respond_with_params WizardQuestion.find(params[:id])
   end
 
+  api :POST, '/wizard_questions', 'Create a wizard question'
+  param :text, String, desc: 'Question text', required: true
+  error code: 422, desc: ParameterValidation::Messages.missing
+
   def create
-    WizardQuestion.create(params_for_wizard_question)
+    WizardQuestion.create(wizard_question_params)
 
     head :ok
   end
 
-  def params_for_wizard_question
-    params.require(:wizard_question).permit(:text)
+  private
+
+  def wizard_question_params
+    params.permit(:text)
   end
 end

--- a/app/models/wizard_question.rb
+++ b/app/models/wizard_question.rb
@@ -12,6 +12,6 @@ class WizardQuestion < ActiveRecord::Base
   has_many :wizard_answers
 
   def next_question_id
-    self.class.find_by('id > ?', id).id
+    self.class.find_by('id > ?', id).try(:id)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :wizard_questions, only: [:show, :create] do
+    resources :wizard_questions, only: [:show, :create, :index] do
       collection do
         get :first
       end
@@ -163,6 +163,7 @@ Rails.application.routes.draw do
     show
     terribly-sorry-about-that
     users
+    wizard
   ).each do |path|
     get "/#{path}" => 'welcome#index'
     get "/#{path}/*path" => 'welcome#index'

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -11,6 +11,118 @@ namespace :sample do
 
   desc 'Generates demo data'
   task demo: :environment do
+    wizard = {
+      'Will this be a public or private cloud?' =>
+      [
+        {
+          text: 'Public',
+          tags_to_add: ['public'],
+          tags_to_remove: ['private']
+        },
+        {
+          text: 'Private',
+          tags_to_add: ['private'],
+          tags_to_remove: ['public']
+        }
+      ],
+      'What programming language will be used?' => [
+        {
+          text: 'PHP',
+          tags_to_add: ['PHP','Linux'],
+          tags_to_remove: ['Windows', 'Java', 'Ruby', 'dotNet']
+        },
+        {
+          text: 'Ruby',
+          tags_to_add: ['Linux', 'Ruby', 'dotNet'],
+          tags_to_remove: ['PHP', 'Windows', 'Java', 'dotNet']
+        },
+        {
+          text: 'Java',
+          tags_to_add: ['Linux', 'Windows', 'Java'],
+          tags_to_remove: ['PHP', 'Ruby', 'dotNet']
+        },
+        {
+          text: 'dotNet',
+          tags_to_add: ['dotNet', 'Windows'],
+          tags_to_remove: ['Linux', 'Java', 'Ruby', 'PHP']
+        },
+        {
+          text: 'Perl',
+          tags_to_add: ['Perl', 'Linux'],
+          tags_to_remove: ['Windows']
+        }
+      ],
+      'Does this require FedRAMP certification?' =>
+      [
+        {
+          text: 'Yes',
+          tags_to_add: ['FedRAMP'],
+          tags_to_remove: []
+        },
+        {
+          text: 'No',
+          tags_to_add: [],
+          tags_to_remove: ['FedRamp']
+        }
+      ],
+      'What FISMA Classifaction is needed?' =>
+      [
+        {
+          text: 'Low',
+          tags_to_add: ['FISMAlow', 'FISMAmedium', 'FISMAhigh'],
+          tags_to_remove: ['FISMAhigh', 'NonFISMA']
+        },
+        {
+          text: 'Medium',
+          tags_to_add: ['FISMAmedium', 'FISMAhigh'],
+          tags_to_remove: ['FISMAlow', 'NonFISMA']
+        },
+        {
+          text: 'High',
+          tags_to_add: ['FISMAhigh'],
+          tags_to_remove: ['FISMAlow', 'FISMAmedium', 'NonFISMA']
+        }
+      ],
+      'What is your preferred Cloud Provider?' =>
+      [
+        {
+          text: 'AWS',
+          tags_to_add: ['AWS'],
+          tags_to_remove: ['VMware', 'Azure']
+        },
+        {
+          text: 'VMWare',
+          tags_to_add: ['VMWare'],
+          tags_to_remove: ['AWS', 'Azure']
+        },
+        {
+          text: 'Azure',
+          tags_to_add: ['Azure'],
+          tags_to_remove: ['AWS', 'VMWare']
+        }
+      ],
+      'Will you require high availability' =>
+      [
+        {
+          text: 'Yes',
+          tags_to_add: ['HA'],
+          tags_to_remove: []
+        },
+        {
+          text: 'No',
+          tags_to_add: [],
+          tags_to_remove: ['HA']
+        }
+      ],
+    }
+
+    wizard.each do |question, answers|
+      unless WizardQuestion.find_by(text: question)
+        question = WizardQuestion.create(text: question)
+        question.wizard_answers.create(answers)
+      end
+    end
+
     Staff.create!([
        { id: 4, first_name: "Unused", last_name: "Staff", email: "unused@projectjellyfish.org", phone: nil, password: "jellyfish", reset_password_token: nil, reset_password_sent_at: nil, remember_created_at: nil, sign_in_count: 0, current_sign_in_at: nil, last_sign_in_at: nil, current_sign_in_ip: nil, last_sign_in_ip: nil, role: 0, deleted_at: nil, secret: 'jellyfish-token'},
        { id: 2, first_name: "ManageIQ", last_name: "Staff", email: "miq@projectjellyfish.org", phone: nil, password: "jellyfish", reset_password_token: nil, reset_password_sent_at: nil, remember_created_at: nil, sign_in_count: 17, current_sign_in_at: "2015-02-06 17:04:10", last_sign_in_at: "2015-02-06 16:57:41", current_sign_in_ip: "54.172.90.47", last_sign_in_ip: "54.172.90.47", role: 1, deleted_at: nil, secret: 'jellyfish-token'},

--- a/public/templates/partials/projects/project.html
+++ b/public/templates/partials/projects/project.html
@@ -127,6 +127,17 @@
             </a>
           </div>
         </div>
+        <div ng-if="wizardPresent" class="add-box">
+          <div class="product-box-shadow">
+            <a ui-sref="base.authed.wizard({projectId: project.id})">
+              <div class="fa-stack">
+                <i class="fa fa-fw fa-stack-2x fa-circle-thin"></i>
+                <i class="fa fa-fw fa-stack-1x fa-plus"></i>
+              </div>
+              <div class="title">Use Wizard to find services</div>
+            </a>
+          </div>
+        </div>
       </section-header>
     </div>
 

--- a/public/templates/partials/wizard/multiple_choice.html
+++ b/public/templates/partials/wizard/multiple_choice.html
@@ -1,0 +1,19 @@
+<div>
+  <select
+    ng-if="options.length > 4"
+    ng-model="$parent.model"
+    ng-options="option.text for option in options"
+  ></select>
+  <label
+    ng-if="options.length <= 4"
+    ng-repeat="option in options"
+  >
+    <input
+      type="radio"
+      name="answer"
+      ng-model="$parent.$parent.model"
+      ng-value="option"
+    />
+    {{option.text}}
+  </label>
+</div>

--- a/public/templates/partials/wizard/question.html
+++ b/public/templates/partials/wizard/question.html
@@ -1,0 +1,16 @@
+<h1>{{vm.question.text}}</h1>
+<multiple-choice
+  options="vm.question.wizard_answers"
+  model="vm.answer"
+  action="vm.nextQuestion"
+></multiple-choice>
+<a
+  ng-if="vm.noMoreQuestions"
+  ui-sref="base.authed.project.addService({projectId: vm.projectId, tags: vm.tags})"
+>
+  View filtered products
+</a>
+
+<p>Tags: {{vm.tags}}
+
+<button ng-click="vm.resetWizard()">Reset Wizard</button>

--- a/spec/factories/wizard_answers.rb
+++ b/spec/factories/wizard_answers.rb
@@ -17,7 +17,10 @@
 
 FactoryGirl.define do
   factory :wizard_answer do
-    text 'Ruby'
+    sequence :text do |n|
+      "The #{n.ordinalize} answer."
+    end
+
     tags_to_add %w(Ruby Linux)
     tags_to_remove %w(Windows Java PHP dotNet)
   end

--- a/spec/factories/wizard_questions.rb
+++ b/spec/factories/wizard_questions.rb
@@ -11,5 +11,11 @@
 FactoryGirl.define do
   factory :wizard_question do
     text 'What programming language will be used?'
+
+    trait :with_answers do
+      after(:build) do |question, _|
+        question.wizard_answers = build_pair(:wizard_answer)
+      end
+    end
   end
 end

--- a/spec/features/user_runs_wizard_spec.rb
+++ b/spec/features/user_runs_wizard_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+feature 'Stack wizard' do
+  scenario 'user runs the Wizard', :js do
+    staff = create(:staff, :admin)
+    login_as(staff)
+    questions = create_pair(:wizard_question, :with_answers)
+    project = create(:project)
+    visit "/project/#{project.id}/wizard"
+
+    expected_tags = questions.inject([]) do |tags, question|
+      expect(page).to have_content(question.text)
+
+      answer = question.wizard_answers.first
+
+      choose answer.text
+      update_tags(tags, answer)
+    end
+    expected_tags = expected_tags.map { |t| "tags=#{t}" }.join('&')
+
+    click_on 'View filtered products'
+
+    expect(page).to have_content('Add Service')
+    expect(URI(current_url).query).to eq expected_tags
+  end
+
+  def update_tags(tags, answer)
+    tags += answer.tags_to_add
+    tags -= answer.tags_to_remove
+    tags.uniq
+  end
+end

--- a/spec/requests/wizard_questions_spec.rb
+++ b/spec/requests/wizard_questions_spec.rb
@@ -51,7 +51,7 @@ describe 'WizardQuestions API' do
     it 'creates a wizard question' do
       sign_in_as create :staff, :admin
 
-      post '/api/v1/wizard_questions', wizard_question: { text: 'Test question?' }
+      post '/api/v1/wizard_questions', text: 'Test question?'
 
       last_wizard_question = WizardQuestion.last
       expect(last_wizard_question.text).to eq('Test question?')


### PR DESCRIPTION
Users can now use a wizard to answer questions that will then dump them
into the add-service page with tags preselected (added to url bar,
they're not being used to filter since there's no filtering built into
the system).

* Create `<multiple-choice>` directive to facilitate switching between
  `input[type=radio]` for few possible answers and `select`s for many.
* Follow https://github.com/johnpapa/angular-styleguide for new files.