### PR TITLE
Create Associations endpoint to add staff to group

### DIFF
--- a/app/controllers/associations_controller.rb
+++ b/app/controllers/associations_controller.rb
@@ -1,0 +1,17 @@
+class AssociationsController < ApplicationController
+  api :POST, '/groups/:group_id/staff/:staff_id', 'Add staff to a group'
+  param :group_id, :number, required: true, desc: 'ID of group to add staff to'
+  param :staff_id, :number, required: true, desc: 'ID of staff to add to group'
+  def create
+    Group.find(params[:group_id]).staff << Staff.find(params[:staff_id])
+    head :ok
+  end
+
+  api :DELETE, '/groups/:group_id/staff/:staff_id', 'Remove staff from a group'
+  param :group_id, :number, required: true, desc: 'ID of group to add staff to'
+  param :staff_id, :number, required: true, desc: 'ID of staff to add to group'
+  def destroy
+    Group.find(params[:group_id]).staff.delete(params[:staff_id])
+    head :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,8 @@ Rails.application.routes.draw do
     patch 'content_pages/revert/:slug', to: 'content_pages#revert'
 
     resources :groups
+    post '/groups/:group_id/staff/:staff_id' => 'associations#create', as: :group_association
+    delete '/groups/:group_id/staff/:staff_id' => 'associations#destroy'
     resources :roles, only: [:index, :create, :update, :destroy]
   end
 

--- a/spec/requests/associations_spec.rb
+++ b/spec/requests/associations_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'Associations API' do
+  describe 'POST create' do
+    it 'adds a user to a group' do
+      sign_in_as create(:staff, :admin)
+      group = create(:group)
+      staff = create(:staff)
+
+      post group_association_path(group, staff)
+
+      expect(response).to be_success
+      expect(group.staff).to eq [staff]
+    end
+  end
+
+  describe 'DELETE destroy' do
+    it 'removes a staff from a group' do
+      sign_in_as create(:staff, :admin)
+      staff = create(:staff)
+      group = create(:group, staff: [staff])
+
+      delete group_association_path(group, staff)
+
+      expect(response).to be_success
+      expect(group.reload.staff).to eq []
+    end
+
+    it '404s if the staff was not on the group' do
+      sign_in_as create(:staff, :admin)
+      staff = create(:staff)
+      group = create(:group)
+
+      delete group_association_path(group, staff)
+
+      expect(response).to be_not_found
+    end
+  end
+end


### PR DESCRIPTION
The previous approach, GETting a group, fiddling with its staff_ids
array, and PUTting it back, was awkward. This should prove a little more
straightforward.

Resolves #666, the neighbor of the pull request.