### PR TITLE
Introduce and use broker-input where appropriate

### DIFF
--- a/app/assets/javascripts/admin/projects/project_question_form.js
+++ b/app/assets/javascripts/admin/projects/project_question_form.js
@@ -19,13 +19,17 @@ function ProjectQuestionForm() {
 
       $scope.removeOption = function(index) {
         $scope.projectQuestion.options.splice(index, 1);
+        delete $scope.projectQuestion["options[" + index + "]"];
       };
 
       $scope.$watch('projectQuestion.field_type', function(newType, lastType) {
         if (newType != lastType && newType === 'select_option') {
           $scope.projectQuestion.options = [''];
-        } else if (newType != lastType && $scope.projectQuestion.options) {
-          $scope.projectQuestion.options = null;
+        } else {
+          angular.forEach($scope.projectQuestion.options, function(_, index) {
+            $scope.removeOption(index);
+          });
+          delete $scope.projectQuestion.options;
         }
       });
     }]

--- a/app/assets/javascripts/forms/input.js
+++ b/app/assets/javascripts/forms/input.js
@@ -1,0 +1,24 @@
+(function() {
+  'use strict';
+
+  angular.module('broker.forms')
+    .directive('brokerInput', BrokerInput);
+
+  function BrokerInput() {
+    return {
+      restrict: 'E',
+      transclude: true,
+      templateUrl: '/templates/partials/forms/broker_input.html',
+      scope: {
+        model: "=",
+        errorPresent: "=",
+        label: "@",
+        name: "@",
+        ngModel: "=",
+        placeholder: "@",
+        required: "=",
+        type: "@",
+      },
+    };
+  };
+}())

--- a/public/templates/partials/admin/products/_form.html
+++ b/public/templates/partials/admin/products/_form.html
@@ -1,16 +1,9 @@
-<input-wrap for="productName" label="Name" errorPresent="productForm.hasError('productName')">
-  <input
-    class="form-control"
-    id="productName"
-    name="productName"
-    ng-model="productForm.product.name"
-    required="true"
-    type="text"
-  />
-  <div class="help-block" ng-show="productForm.hasError('productName', 'required')">
+<broker-input name="name" label="Name" errorPresent="productForm.hasError('name')"
+    model="productForm.product" required="true" >
+  <div class="help-block" ng-show="productForm.hasError('name', 'required')">
     <span class="help-text">A name is required for all products</span>
   </div>
-</input-wrap>
+</broker-input>
 
 <input-wrap for="productDescription" label="Description" required=true>
   <textarea
@@ -47,10 +40,9 @@
   </div>
 </input-wrap>
 
-<input-wrap for="productActive" label="Active?">
-  <input id="productActive" name="productActive" type="checkbox" ng-model="productForm.product.active" class="form-control" />
+<broker-input name="active" label="Active?" type="checkbox" model="productForm.product">
   <div class="help-text">Only active products are displayed in the marketplace.</div>
-</input-wrap>
+</broker-input>
 
 <input-wrap for="{{price.id}}" label="{{price.name}}" ng-repeat="price in productForm.prices" errorPresent="productForm.hasError(price.id)">
   <input

--- a/public/templates/partials/admin/projects/project_question_form.html
+++ b/public/templates/partials/admin/projects/project_question_form.html
@@ -1,22 +1,14 @@
 <form class="form-horizontal" role="form" name="projectQuestionForm">
-  <input-wrap for="question" label="Question">
-    <input class="form-control" id="question" name="question"
-      ng-model='projectQuestion.question' placeholder="Enter question here" required>
-  </input-wrap>
+  <broker-input name="question" label="Question"
+    model='projectQuestion' placeholder="Enter question here" required="true"></broker-input>
 
-  <input-wrap for="helpText" label="Help Text">
-    <input class="form-control" id="helpText" name="helpText"
-      ng-model='projectQuestion.help_text' placeholder="Enter help text" required>
-  </input-wrap>
+  <broker-input name="help_text" label="Help Text"
+    model='projectQuestion' placeholder="Enter help text" required="true"></broker-input>
 
-  <input-wrap for="loadOrder" label="Load Order">
-    <input type="number" class="form-control" id="loadOrder" name="loadOrder"
-      ng-model='projectQuestion.load_order' placeholder="Enter order number" required>
-  </input-wrap>
+  <broker-input name="load_order" label="Load Order" type="number"
+    model='projectQuestion' placeholder="Enter order number" required="true"></broker-input>
 
-  <input-wrap for="required" label="Required">
-    <input class="form-control" type="checkbox" ng-model='projectQuestion.required'>
-  </input-wrap>
+  <broker-input for="required" label="Required" type="checkbox" model='projectQuestion'></broker-input>
 
   <input-wrap for="fieldType" label="Field Type">
     <select name="fieldType" class="form-control" ng-model='projectQuestion.field_type' required>
@@ -27,14 +19,16 @@
     </select>
   </input-wrap>
 
-  <input-wrap label="Option {{$index + 1}}" ng-repeat="option in projectQuestion.options track by $index">
-    <input ng-model='projectQuestion.options[$index]' class="form-control" placeholder="Enter option">
+  <broker-input label="Option {{$index + 1}}" ng-repeat="option in projectQuestion.options track by $index"
+  name='options[{{$index}}]' placeholder="Enter option" model="projectQuestion"
+  >
     <a type="button" ng-click="removeOption($index)"><i class="fa fa-lg fa-times"></i></a>
-  </input-wrap>
+  </broker-input>
 
   <br />
 
-  <a type="button" class="btn btn-default btn-option" ng-click="addOption()">+ Add Option</a>
+  <a type="button" class="btn btn-default btn-option" ng-click="addOption()"
+    ng-if="projectQuestion.field_type === 'select_option'">+ Add Option</a>
 
   <br />
 

--- a/public/templates/partials/admin/users/_form.html
+++ b/public/templates/partials/admin/users/_form.html
@@ -1,48 +1,40 @@
-<input-wrap for="first_name" label="First Name" errorPresent="adminUserFormCtrl.hasError('first_name')">
-  <input id="first_name" name="first_name" type="text" ng-model="adminUserFormCtrl.user.first_name" ng-change="adminUserFormCtrl.clearSubmitError('first_name')" class="form-control" required/>
+<broker-input name="first_name" label="First Name" model="adminUserFormCtrl.user" required="true" errorPresent="adminUserFormCtrl.hasError('first_name')" >
   <div class="help-block">
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('first_name', 'required')">First Name is Required.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('first_name', 'submitError')">{{adminUserFormCtrl.getSubmitErrorValue('first_name')}}</div>
   </div>
-</input-wrap>
+</broker-input>
 
-<input-wrap for="last_name" label="Last Name" errorPresent="adminUserFormCtrl.hasError('last_name')">
-  <input id="last_name" name="last_name" type="text" ng-model="adminUserFormCtrl.user.last_name" ng-change="adminUserFormCtrl.clearSubmitError('last_name')" class="form-control" required/>
+<broker-input name="last_name" label="Last Name" model="adminUserFormCtrl.user" required="true" errorPresent="adminUserFormCtrl.hasError('last_name')" >
   <div class="help-block">
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('last_name', 'required')">Last Name is Required.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('last_name', 'submitError')">{{adminUserFormCtrl.getSubmitErrorValue('last_name')}}</div>
   </div>
-</input-wrap>
+</broker-input>
 
-<input-wrap for="email" label="Email" errorPresent="adminUserFormCtrl.hasError('email')">
-  <input id="email" name="email" type="email" ng-model="adminUserFormCtrl.user.email" ng-change="adminUserFormCtrl.clearSubmitError('email')" class="form-control" required/>
-
+<broker-input name="email" label="Email" model="adminUserFormCtrl.user" required="true" errorPresent="adminUserFormCtrl.hasError('email')" type="email">
   <div class="help-block">
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('email', 'required')">Email Address is Required.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('email', 'email')">Email Address is Not Valid.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('email', 'submitError')">{{adminUserFormCtrl.getSubmitErrorValue('email')}}</div>
   </div>
-</input-wrap>
+</broker-input>
 
-<input-wrap for="password" label="Password" errorPresent="adminUserFormCtrl.hasError('password')">
-  <input id="password" name="password" type="password" ng-minlength=8 ng-model="adminUserFormCtrl.user.password" ng-change="adminUserFormCtrl.clearSubmitError('password')" class="form-control" ng-required="!adminUserFormCtrl.user.id" />
-
+<broker-input name="password" label="Password" model="adminUserFormCtrl.user" required="true" errorPresent="adminUserFormCtrl.hasError('password')" type="password">
   <div class="help-block">
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password', 'required')">Password is Required.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password', 'minlength')">Password must be at least 8 Characters.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password', 'submitError')">{{adminUserFormCtrl.getSubmitErrorValue('password')}}</div>
   </div>
-</input-wrap>
+</broker-input>
 
-<input-wrap for="password_confirmation" label="Confirm Password" errorPresent="adminUserFormCtrl.hasError('password_confirmation')">
-  <input id="password_confirmation" name="password_confirmation" type="password" ng-model="adminUserFormCtrl.user.password_confirmation" ng-change="adminUserFormCtrl.clearSubmitError('password_confirmation')" class="form-control" compare-to="adminUserFormCtrl.user.password" ng-required="!adminUserFormCtrl.user.id" />
-
+<broker-input name="password_confirmation" label="Confirm Password" model="adminUserFormCtrl.user" required="true" errorPresent="adminUserFormCtrl.hasError('password_confirmation')" type="password">
   <div class="help-block">
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password_confirmation', 'required')">Confirm Password is Required.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password_confirmation', 'compareTo')">Passwords Must Match.</div>
     <div class="help-text" ng-show="adminUserFormCtrl.hasError('password_confirmation', 'submitError')">{{adminUserFormCtrl.getSubmitErrorValue('password_confirmation')}}</div>
   </div>
-</input-wrap>
+</broker-input>
 
 <input-wrap for="role" label="Role" errorPresent="adminUserFormCtrl.hasError('role')" >
   <ui-select id="role" name="role" ng-model="adminUserFormCtrl.user.role" ng-change="adminUserFormCtrl.clearSubmitError('role')" theme="selectize" required />

--- a/public/templates/partials/forms/broker_input.html
+++ b/public/templates/partials/forms/broker_input.html
@@ -1,0 +1,6 @@
+<input-wrap errorPresent="errorPresent" for="{{name}}" label="{{label}}">
+<input type="{{type||'text'}}" name="{{name}}" ng-model="model[name]"
+  class="form-control" id="{{name}}" placeholder="{{placeholder}}"
+  ng-required="{{required}}" />
+  <ng-transclude></ng-transclude>
+</input-wrap>

--- a/public/templates/partials/projects/groups_input.html
+++ b/public/templates/partials/projects/groups_input.html
@@ -1,14 +1,16 @@
 <section-header name="Groups">
-  <div angucomplete-alt
-    id="group_search"
-    placeholder="Search groups"
-    selected-object="addGroupToProject"
-    local-data="unaddedGroups"
-    search-fields="name"
-    title-field="name"
-    clear-selected="true"
-    minlength="0"
-  />
+  <input-wrap label="Search Groups" for="group_search_value">
+    <div angucomplete-alt
+      id="group_search"
+      selected-object="addGroupToProject"
+      local-data="unaddedGroups"
+      search-fields="name"
+      title-field="name"
+      clear-selected="true"
+      input-class="form-control"
+      minlength="0"
+    />
+  </input-wrap>
 
   <ul id="groups-list">
     <li ng-attr-id="{{'group-' + group.id}}" class="group" ng-repeat="group in project.groups">

--- a/public/templates/partials/projects/project_form.html
+++ b/public/templates/partials/projects/project_form.html
@@ -1,11 +1,6 @@
 <form class="form-horizontal padded horizontal-spanning" role="form" name="projectForm" novalidate>
-  <input-wrap errorPresent="projectForm.name.$invalid && projectForm.name.$dirty" for="name" label="Name">
-    <input name="name" ng-model='project.name' class="form-control" id="name" placeholder="Project Name" required>
-  </input-wrap>
-
-  <input-wrap errorPresent="projectForm.img.$invalid && projectForm.img.$dirty" for="img" label="Icon">
-    <input name="img" ng-model='project.img' class="form-control" id="img" placeholder="Full address (with http://) to icon image" required>
-  </input-wrap>
+  <broker-input label="Name" name="name" placeholder="Project Name" model="project" required="true"></broker-input>
+  <broker-input label="Icon" name="img" placeholder="Full address (with http://) to icon image" model="project" required="false"></broker-input>
 
   <input-wrap errorPresent="projectForm.budget.$invalid && projectForm.budget.$dirty" for="budget" label="Budget">
     <input name="budget" type="text" class="form-control" id="budget" ng-model='project.budget' ng-currency>


### PR DESCRIPTION
`<broker-input>` is a shortcut for an `<input>` wrapped in an
`<input-wrap>` directive and handles the simplest (and most common) case
for its use.

A likely future improvement here would be either to introduce
`<broker-textarea>` and `<broker-select>` for those form controls, but I
think this change itself is valuable.