### PR TITLE
Temporarily fix tag_list in API

### DIFF
--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -22,9 +22,13 @@
 #
 
 class ProductSerializer < ApplicationSerializer
-  attributes :id, :name, :description, :active, :img, :created_at, :updated_at, :deleted_at, :setup_price, :hourly_price, :monthly_price, :provisioning_answers, :product_type, :tag_list
+  attributes :id, :name, :description, :active, :img, :created_at, :updated_at, :deleted_at, :setup_price, :hourly_price, :monthly_price, :provisioning_answers, :product_type
 
   def product_type
     object.product_type.name
+  end
+  
+  def tag_list
+    object.tag_list_on(object.product_type.name.parameterize.underscore.downcase.to_sym)
   end
 end


### PR DESCRIPTION
This should be reverted and the underlying problem solved, which is that
the `taggable_tags` stuff is not creating regular, unscoped tags
anymore.

If we're just trying to get tags by product_type, I think there's
probably SQL we can do to make that happen a little more cleanly. Ping
me.