### PR TITLE
Feature/add product tags method

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,9 +6,11 @@ class ProductsController < ApplicationController
   before_action :load_product, only: [:show, :update, :destroy]
   before_action :load_products, only: [:index]
 
+  PRODUCT_METHODS = %w(tags)
   PRODUCT_PRICE_REGEX = /\d{1,6}(\.\d{0,4})?/
 
   api :GET, '/products', 'Returns a collection of products'
+  param :methods, Array, in: PRODUCT_METHODS
   param :page, :number
   param :per_page, :number
   param :active, :bool
@@ -38,6 +40,7 @@ class ProductsController < ApplicationController
   end
 
   api :PUT, '/products/:id', 'Updates product with :id'
+  param :methods, Array, in: PRODUCT_METHODS
   param :id, :number, required: true
   param :active, :bool, desc: 'Product is active and available in the marketplace'
   param :description, String, desc: 'Short description', required: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -36,6 +36,6 @@ class Product < ActiveRecord::Base
   end
 
   def tags
-    self.tag_list
+    tag_list
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,4 +34,8 @@ class Product < ActiveRecord::Base
   def product_type
     ProductType.new(self[:product_type])
   end
+
+  def tags
+    self.tag_list
+  end
 end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -22,7 +22,7 @@
 #
 
 class ProductSerializer < ApplicationSerializer
-  attributes :id, :name, :description, :active, :img, :created_at, :updated_at, :deleted_at, :setup_price, :hourly_price, :monthly_price, :provisioning_answers, :product_type
+  attributes :id, :name, :description, :active, :img, :created_at, :updated_at, :deleted_at, :setup_price, :hourly_price, :monthly_price, :provisioning_answers, :product_type, :tags
 
   def product_type
     object.product_type.name


### PR DESCRIPTION
Addresses issue https://github.com/projectjellyfish/api/issues/691

Changes:
- adds `tags` method onto products model
- adds `PRODUCT_METHODS` array to products_controller.rb
- adds `tags` to product serializer
- adds spec to verify that appending `?methods[]=tags` onto the products endpoint will return tags
