### PR TITLE
Feature/fix empty repeated project questions

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -37,8 +37,8 @@ class ProjectsController < ApplicationController
   error code: 404, desc: MissingRecordDetection::Messages.not_found
 
   def show
-    build_empty_answers_to_questions(project)
     authorize_and_normalize(project)
+    build_empty_answers_to_questions(project) if project.project_answers.empty?
     respond_with_params project
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,5 +28,4 @@ RSpec.configure do |config|
   end
 
   Capybara.javascript_driver = :poltergeist
-  Apipie.record('examples')
 end


### PR DESCRIPTION
fixes https://github.com/projectjellyfish/api/issues/640

makes default behavior of projects to populate empty project answers only if no answers exist for the project. 
