### PR TITLE
Fixed reordering issue on the API side for project questions. Also re…

### DIFF
--- a/app/controllers/project_questions_controller.rb
+++ b/app/controllers/project_questions_controller.rb
@@ -1,8 +1,4 @@
 class ProjectQuestionsController < ApplicationController
-  before_action :load_project_question, only: [:show, :update, :destroy]
-  before_action :load_project_question_params, only: [:create, :update]
-  before_action :load_project_questions, only: [:index]
-
   after_action :verify_authorized
 
   api :GET, '/project_questions', 'Returns a collection of project_questions'
@@ -11,8 +7,7 @@ class ProjectQuestionsController < ApplicationController
   param :includes, Array, required: false, in: %w(project)
 
   def index
-    authorize ProjectQuestion
-    respond_with_params @project_questions
+    respond_with_params project_questions
   end
 
   api :GET, '/project_questions/:id', 'Shows project_question with :id'
@@ -21,8 +16,7 @@ class ProjectQuestionsController < ApplicationController
   error code: 404, desc: MissingRecordDetection::Messages.not_found
 
   def show
-    authorize @project_question
-    respond_with_params @project_question
+    respond_with_params project_question
   end
 
   api :POST, '/project_questions', 'Creates project_question'
@@ -35,10 +29,8 @@ class ProjectQuestionsController < ApplicationController
   error code: 422, desc: ParameterValidation::Messages.missing
 
   def create
-    @project_question = ProjectQuestion.new @project_question_params
-    authorize @project_question
-    @project_question.save
-    respond_with @project_question
+    authorize ProjectQuestion
+    respond_with ProjectQuestion.create project_question_params
   end
 
   api :PUT, '/project_questions/:id', 'Updates project_question with :id'
@@ -47,15 +39,13 @@ class ProjectQuestionsController < ApplicationController
   param :field_type, String, desc: 'Field Type', in: %w(check_box select_option text date)
   param :help_text, String, desc: 'Help Text'
   param :load_order, :number, desc: 'Load order'
-  param :options, Array, desc: 'Options'
+  param :options, Array, desc: 'Options', allow_nil: true
   param :required, :bool, desc: 'Required', allow_nil: true
   error code: 404, desc: MissingRecordDetection::Messages.not_found
   error code: 422, desc: ParameterValidation::Messages.missing
 
   def update
-    authorize @project_question
-    @project_question.update_attributes @project_question_params
-    respond_with @project_question
+    respond_with project_question.update_attributes project_question_params
   end
 
   api :DELETE, '/project_questions/:id', 'Deletes project_question with :id'
@@ -63,23 +53,24 @@ class ProjectQuestionsController < ApplicationController
   error code: 404, desc: MissingRecordDetection::Messages.not_found
 
   def destroy
-    authorize @project_question
-    @project_question.destroy
-    respond_with @project_question
+    respond_with project_question
   end
 
   private
 
-  def load_project_question_params
-    @project_question_params = params.permit(:question, :field_type, :help_text, :required, :load_order, options: [])
+  def project_question_params
+    params.permit(:question, :field_type, :help_text, :required, :load_order, options: [])
   end
 
-  def load_project_question
-    @project_question = ProjectQuestion.find(params.require(:id))
+  def project_question
+    @project_question = ProjectQuestion.find(params.require(:id)).tap { |q| authorize q }
   end
 
-  def load_project_questions
+  def project_questions
     # TODO: Use a FormObject to encapsulate search filters, ordering, pagination
-    @project_questions = query_with ProjectQuestion.all, :includes, :pagination
+    @project_questions ||= begin
+      authorize ProjectQuestion
+      query_with ProjectQuestion.all.order(:load_order), :includes, :pagination
+    end
   end
 end

--- a/lib/tasks/sample.rake
+++ b/lib/tasks/sample.rake
@@ -200,13 +200,13 @@ namespace :sample do
     Project.connection.execute("ALTER SEQUENCE projects_id_seq RESTART #{Project.all.order('id DESC').first.id + 1}")
 
     ProjectQuestion.create!([
-      { id: 1, question: "Project Description", help_text: "", required: true, deleted_at: nil, load_order: nil, options: [], field_type: 2},
-      { id: 2, question: "Project Charge Code", help_text: "", required: true, deleted_at: nil, load_order: nil, options: [], field_type: 2},
-      { id: 3, question: "Maintenance Day", help_text: "", required: true, deleted_at: nil, load_order: nil, options: [], field_type: 3},
-      { id: 4, question: "Performed Maintenance", help_text: "", required: true, deleted_at: nil, load_order: nil, options: [], field_type: 0},
-      { id: 5, question: "Default provisioning location", help_text: "", required: true, deleted_at: nil, load_order: nil, options: ["East Coast Data Center", "West Coast Data Center", "Classified Data Center"], field_type: 1},
-      { id: 6, question: "Will this run in production?", help_text: "", required: true, deleted_at: nil, load_order: nil, options: ["Yes", "No"], field_type: 1},
-      { id: 7, question: "FISMA Classification", help_text: "", required: true, deleted_at: nil, load_order: nil, options: ["Low", "Medium", "High"], field_type: 1},
+      { id: 1, question: "Project Description", help_text: "", required: true, deleted_at: nil, load_order: 2, options: [], field_type: 2},
+      { id: 2, question: "Project Charge Code", help_text: "", required: true, deleted_at: nil, load_order: 3, options: [], field_type: 2},
+      { id: 3, question: "Maintenance Day", help_text: "", required: true, deleted_at: nil, load_order: 4, options: [], field_type: 3},
+      { id: 4, question: "Performed Maintenance", help_text: "", required: true, deleted_at: nil, load_order: 5, options: [], field_type: 0},
+      { id: 5, question: "Default provisioning location", help_text: "", required: true, deleted_at: nil, load_order: 6, options: ["East Coast Data Center", "West Coast Data Center", "Classified Data Center"], field_type: 1},
+      { id: 6, question: "Will this run in production?", help_text: "", required: true, deleted_at: nil, load_order: 7, options: ["Yes", "No"], field_type: 1},
+      { id: 7, question: "FISMA Classification", help_text: "", required: true, deleted_at: nil, load_order: 8, options: ["Low", "Medium", "High"], field_type: 1},
       { id: 8, question: "Period of Performance", help_text: "in months", required: nil, deleted_at: nil, load_order: 1, field_type: 2}
     ])
     ProjectQuestion.connection.execute("ALTER SEQUENCE project_questions_id_seq RESTART #{ProjectQuestion.all.order('id DESC').first.id + 1}")

--- a/src/client/app/states/admin/project-questions/list/list.state.js
+++ b/src/client/app/states/admin/project-questions/list/list.state.js
@@ -97,7 +97,7 @@
     function sortableUpdate(event, ui) {
       var projectQuestion = angular.element(ui.item).scope().row;
 
-      // Update fires before the mode is updated; Stop won't tell us if we actualyl moved anything
+      // Update fires before the mode is updated; Stop won't tell us if we actually moved anything
       // So wait a moment and let things settle then perform the update
       $timeout(savePosition);
 


### PR DESCRIPTION
…factored the code to use the latest style.

This fixes the API side of things for #749, there's still a UX bug I was trying to fix. Anytime a question gets reordered, it's only updating load_order for the selected question so two questions will end up with the same load_order.
Not sure if this should be a fix on the UX side or on the API side...