### PR TITLE
prevents non admins from editing project budget after creation.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -86,6 +86,7 @@ class ProjectsController < ApplicationController
         project[:project_answers_attributes] = project.delete(:project_answers)
       end
     end
+    @_project_params = (!current_user.admin? && !params[:id].nil?) ? @_project_params.delete(:budget) : @_project_params
   end
 
   def authorize_and_normalize(project)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -85,8 +85,10 @@ class ProjectsController < ApplicationController
       if params[:project_answers]
         project[:project_answers_attributes] = project.delete(:project_answers)
       end
+      if !current_user.admin? && !project[:id].nil?
+        project.delete(:budget)
+      end
     end
-    @_project_params = (!current_user.admin? && !params[:id].nil?) ? @_project_params.delete(:budget) : @_project_params
   end
 
   def authorize_and_normalize(project)


### PR DESCRIPTION
if the user is not an admin and attempts to update the budget of an existing project, they are prevented from doing so by deleting the budget param from their request.
assumes that when a project id is passed as a param then an update is being handled.
addresses issue https://github.com/projectjellyfish/api/issues/146