### PR TITLE
Use console syntax to execute scheduled rake tasks.

### DIFF
--- a/config/initializers/task_scheduler.rb
+++ b/config/initializers/task_scheduler.rb
@@ -8,9 +8,9 @@ require 'rake'
 scheduler = Rufus::Scheduler.new
 
 scheduler.every '24h' do
-  system('rake upkeep:prune_alerts')
+  system('bundle exec rake upkeep:prune_alerts')
 end
 
 scheduler.every '15m' do
-  system('rake upkeep:update_budgets')
+  system('bundle exec rake upkeep:update_budgets')
 end

--- a/config/initializers/task_scheduler.rb
+++ b/config/initializers/task_scheduler.rb
@@ -8,9 +8,9 @@ require 'rake'
 scheduler = Rufus::Scheduler.new
 
 scheduler.every '24h' do
-  Rake::Task['upkeep:prune_alerts']
+  system('rake upkeep:prune_alerts')
 end
 
 scheduler.every '15m' do
-  Rake::Task['upkeep:update_budgets']
+  system('rake upkeep:update_budgets')
 end


### PR DESCRIPTION
Addresses issue https://github.com/projectjellyfish/api/issues/831.

Use console syntax to execute scheduled rake tasks.

Stackoverflow [suggested](http://stackoverflow.com/questions/8049361/rufus-scheduler-fails-with-rake-tasks-dont-know-how-to-build-task) this approach and it seemed to work. 