### PR TITLE
Toggle project approval visibility on undecided

### DIFF
--- a/src/client/app/components/project-approval/project-approval.html
+++ b/src/client/app/components/project-approval/project-approval.html
@@ -1,5 +1,5 @@
 <div ng-if="::'approved' !== vm.project.status">
-  <div ng-if="::'pending' === vm.project.status" class="project-approval">
+  <div ng-if="::'undecided' === vm.project.status" class="project-approval">
       <div class="project-approval__heading">
         Project Pending, Requires
         <span class="project-approval__heading--approval">Approval</span>


### PR DESCRIPTION
Project approval template previously required project status to be
`pending` in order to display the project approval forum. Project status
has changed to `undecided` for projects awaiting approval.

Resolves: JEL-5