### PR TITLE
Rollback use case changes per Stack's feedback

### DIFF
--- a/app/use_cases/create_service_order.rb
+++ b/app/use_cases/create_service_order.rb
@@ -42,14 +42,16 @@ class CreateServiceOrder
       fail UnapprovedProject, "Project '#{project.name}' has not been approved."
     end
 
-    unless params[:name].present?
+    unless params[:service]['name'].present?
       fail UnnamedService, 'A name for the service was not given.'
     end
   end
 
   def build_service
+    service_params = params.delete :service
+
     service.type = service.class.to_s
-    service.name = params[:name]
+    service.name = service_params['name']
     service.status = :pending
     service.status_msg = 'Provisioning service...'
   end
@@ -61,7 +63,7 @@ class CreateServiceOrder
       hourly_price: product.hourly_price,
       monthly_price: product.monthly_price,
       service: service
-    ).except(:name)
+    )
 
     order_params['answers_attributes'] = [] unless order_params['answers_attributes']
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -101,12 +101,12 @@ describe 'Project.monthly_spend' do
     CreateServiceOrder.perform user,
       project_id: project.id,
       product_id: product.id,
-      name: 'Service 1'
+      service: { 'name' => 'Service 1' }
 
     CreateServiceOrder.perform user,
       project_id: project.id,
       product_id: product.id,
-      name: 'Service 2'
+      service: { 'name' => 'Service 2' }
 
     project.reload
 


### PR DESCRIPTION
Corrected project spec to pass a service hash to the CreateServiceOrder
object as it expects to receive in the OrdersController. Rolled back
changes to CreateServiceOrder object per Stack' feedback to previous
implementation.

Resolves: JEL-43