### PR TITLE
Project Details status edited to uppercase; edited status color modifiers

### DIFF
--- a/src/client/app/components/status/_status.sass
+++ b/src/client/app/components/status/_status.sass
@@ -7,10 +7,16 @@
   +modifier(success)
     color: $app-color-green
 
+  +modifier(approved)
+    color: $app-color-green
+
   +modifier(critical)
     color: $app-color-pink
 
   +modifier(danger)
+    color: $app-color-pink
+
+  +modifier(rejected)
     color: $app-color-pink
 
   +modifier(error)
@@ -20,6 +26,9 @@
     color: $app-color-orange
 
   +modifier(unknown)
+    color: $app-color-blue
+
+  +modifier(undecided)
     color: $app-color-blue
 
   +modifier(info)

--- a/src/client/app/states/projects/details/details.html
+++ b/src/client/app/states/projects/details/details.html
@@ -25,7 +25,7 @@
   <div class="details-table__row">
     <div class="details-table__label">Status</div>
     <div class="details-table__detail">
-      <status type="{{ ::vm.project.status }}">{{ ::vm.project.status }}</status>
+      <status type="{{ ::vm.project.status }}">{{ ::vm.project.status | uppercase }}</status>
     </div>
   </div>
 


### PR DESCRIPTION
Example of the uppercase status, colored with green (approved), red (rejected) or blue (undecided).
<img width="866" alt="screen shot 2015-09-25 at 11 11 42 am" src="https://cloud.githubusercontent.com/assets/5269893/10104184/40475a80-6376-11e5-994e-89c49a68e4e6.png">
<img width="928" alt="screen shot 2015-09-25 at 11 12 41 am" src="https://cloud.githubusercontent.com/assets/5269893/10104201/5ff85e56-6376-11e5-8fab-f81b2b48249a.png">
<img width="1208" alt="screen shot 2015-09-25 at 11 13 11 am" src="https://cloud.githubusercontent.com/assets/5269893/10104222/7456ab14-6376-11e5-8693-4938884781a0.png">
