### PR TITLE
Downgrade Apipie to 0.3.3 to avoid issue with `content_tag`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :test do
 end
 
 # Documentation
-gem 'apipie-rails', '~> 0.3.0'
+gem 'apipie-rails', '0.3.3'
 
 # Keep but hide deleted records
 gem 'paranoia'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
     annotate (2.6.10)
       activerecord (>= 3.2, <= 4.3)
       rake (~> 10.4)
-    apipie-rails (0.3.4)
+    apipie-rails (0.3.3)
       json
     arel (6.0.3)
     ast (2.1.0)
@@ -290,7 +290,7 @@ GEM
     ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
     rubyzip (1.1.7)
-    rufus-scheduler (3.1.5)
+    rufus-scheduler (3.1.6)
     sass (3.4.18)
     seed_dump (3.2.2)
       activerecord (~> 4)
@@ -353,7 +353,7 @@ DEPENDENCIES
   acts-as-taggable-on
   acts_as_list
   annotate
-  apipie-rails (~> 0.3.0)
+  apipie-rails (= 0.3.3)
   awesome_print
   bcrypt (~> 3.1.7)
   brakeman

--- a/lib/jellyfish/extension.rb
+++ b/lib/jellyfish/extension.rb
@@ -129,8 +129,8 @@ module Jellyfish
     def mount_extension(engine, options)
       @mount = {
         engine: engine,
-        options: options
-      }
+        options: options.freeze
+      }.freeze
     end
 
     def pending_migrations

--- a/lib/jellyfish/routing.rb
+++ b/lib/jellyfish/routing.rb
@@ -4,7 +4,7 @@ module ActionDispatch
       def mount_extensions
         Jellyfish::Extension.all.each do |ex|
           next unless ex.mount
-          mount ex.mount[:engine], ex.mount[:options]
+          mount ex.mount[:engine], ex.mount[:options].dup
         end
       end
     end


### PR DESCRIPTION
- Use `dup`ped options when mounting extensions
- Freeze mount options for each extension so that future changes will raise errors if they are being altered