### PR TITLE
Provide storage for output from provisioning services

### DIFF
--- a/app/models/concerns/value_types.rb
+++ b/app/models/concerns/value_types.rb
@@ -1,25 +1,64 @@
 module ValueTypes
   extend ActiveSupport::Concern
 
+  TYPES = {
+    string: 0,
+    password: 1,
+    integer: 2,
+    boolean: 3,
+    array: 4,
+    json: 5,
+    date: 6,
+    datetime: 7,
+    fingerprint: 8,
+    certificate: 9,
+    text: 10,
+    url: 11,
+    email: 12,
+    cidr: 13
+  }
+
   included do
     validates :value, uri: true, if: -> (s) { s.value_type == 'url' }
     validates :value, email: true, if: -> (s) { s.value_type == 'email' }
+    validates :value, numericality: { only_integer: true }, if: -> (s) { s.value_type == 'integer' }
+    validates :value_type, inclusion: ValueTypes::TYPES.keys.map(&:to_s)
+
     # TODO: Add more type validations
 
-    enum value_type: {
-      string: 0,
-      password: 1,
-      integer: 2,
-      boolean: 3,
-      array: 4,
-      json: 5,
-      date: 6,
-      datetime: 7,
-      fingerprint: 8,
-      certificate: 9,
-      text: 10,
-      url: 11,
-      email: 12
-    }
+    enum value_type: ValueTypes::TYPES
+
+    def value
+      self[:value].nil? ? nil : YAML.load(self[:value])
+    end
+
+    private
+
+    def parse_string_value
+      begin
+        v = Jellyfish::Cast::String.cast(self[:value], value_type)
+        self[:value] = v.to_yaml
+      rescue Jellyfish::Cast::FailedCastException => e
+        invalid_value_error e.to_s
+        return false
+      rescue Jellyfish::Cast::UnhandledCastException
+        raise StandardError, "parsing settings type '#{value_type}' from string is not defined"
+      end
+      true
+    end
+
+    # Convert/Cast the value to the proper type
+    def convert_value
+      # Do nothing if value has not changed
+      return true unless value_changed?
+      # Cast the value and return success
+      return parse_string_value if self[:value].is_a? String
+      # Convert the value to yaml otherwise
+      self[:value] = self[:value].to_yaml unless self[:value].nil?
+    end
+
+    def invalid_value_error(error)
+      errors.add :value, "is invalid: #{error}"
+    end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -23,6 +23,7 @@ class Service < ActiveRecord::Base
 
   has_many :alerts, as: :alertable
   has_many :latest_alerts, -> { latest }, class_name: 'Alert', as: :alertable
+  has_many :service_outputs
 
   has_one :order
   has_one :project, through: :order

--- a/app/models/service_output.rb
+++ b/app/models/service_output.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: service_outputs
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  service_id :integer          not null
+#  name       :string           not null
+#  value      :text
+#  value_type :integer
+#
+# Indexes
+#
+#  index_service_outputs_on_service_id  (service_id)
+#
+
+class ServiceOutput < ActiveRecord::Base
+  include ValueTypes
+
+  belongs_to :service
+
+  validates :name, presence: true
+
+  before_save :convert_value
+end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,7 +1,7 @@
 class UriValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     record.errors.add attribute, 'must be a valid URI' unless %w(http https).include? URI(value).scheme
-  rescue URI::InvalidURIError
+  rescue URI::InvalidURIError, ArgumentError
     record.errors.add attribute, 'must be a valid URI'
   end
 end

--- a/db/data/sample/projects.yml
+++ b/db/data/sample/projects.yml
@@ -20,6 +20,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'true'
+      value_type: boolean
     - question: loc
       value: West Coast Data Center
     - question: prod
@@ -28,6 +29,7 @@
       value: High
     - question: period
       value: 5
+      value_type: integer
 - _assoc: mobile
   name: Widgets Co Mobile API
   description: Collections of services for running the Widgets Co. mobile API services
@@ -49,6 +51,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'true'
+      value_type: boolean
     - question: loc
       value: West Coast Data Center
     - question: prod
@@ -57,6 +60,7 @@
       value: High
     - question: period
       value: 5
+      value_type: integer
 - _assoc: blog
   name: Widgets Co. Blog
   description: The Widgets Co. blog site
@@ -81,6 +85,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'false'
+      value_type: boolean
     - question: loc
       value: West Coast Data Center
     - question: prod
@@ -89,6 +94,7 @@
       value: High
     - question: period
       value: 5
+      value_type: integer
 - _assoc: files
   name: Cloud File Share
   description: A Widget Co. cloud sharing service
@@ -106,6 +112,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'true'
+      value_type: boolean
     - question: loc
       value: East Coast Data Center
     - question: prod
@@ -114,6 +121,7 @@
       value: High
     - question: period
       value: 5
+      value_type: integer
 - _assoc: exchange
   name: Cloud Exchange
   description: Another great project underway for Widget Co.
@@ -131,6 +139,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'true'
+      value_type: boolean
     - question: loc
       value: Europe
     - question: prod
@@ -139,6 +148,7 @@
       value: High
     - question: period
       value: 5
+      value_type: integer
 - _assoc: jellyfish
   name: Project Jellyfish Demo
   description: A demo project for showcasing the features of Project Jellyfish.
@@ -156,6 +166,7 @@
       value: 2015-05-20T05:00:00.000Z
     - question: do_maint
       value: 'true'
+      value_type: boolean
     - question: loc
       value: East Coast Data Center
     - question: prod
@@ -164,3 +175,4 @@
       value: High
     - question: period
       value: 5
+      value_type: integer

--- a/db/migrate/20151009194552_rename_service_attributes.rb
+++ b/db/migrate/20151009194552_rename_service_attributes.rb
@@ -1,0 +1,5 @@
+class RenameServiceAttributes < ActiveRecord::Migration
+  def change
+    rename_table :service_attributes, :service_outputs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150917174153) do
+ActiveRecord::Schema.define(version: 20151009194552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -339,7 +339,7 @@ ActiveRecord::Schema.define(version: 20150917174153) do
     t.jsonb  "permissions"
   end
 
-  create_table "service_attributes", force: :cascade do |t|
+  create_table "service_outputs", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "service_id", null: false
@@ -348,7 +348,7 @@ ActiveRecord::Schema.define(version: 20150917174153) do
     t.integer  "value_type"
   end
 
-  add_index "service_attributes", ["service_id"], name: "index_service_attributes_on_service_id", using: :btree
+  add_index "service_outputs", ["service_id"], name: "index_service_outputs_on_service_id", using: :btree
 
   create_table "services", force: :cascade do |t|
     t.datetime "created_at",             null: false

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -16,12 +16,31 @@
 #  index_answers_on_answerable_type_and_answerable_id  (answerable_type,answerable_id)
 #
 
-class Answer < ActiveRecord::Base
-  include ValueTypes
+FactoryGirl.define do
+  factory :answer do
+    sequence :name do |n|
+      "answer_#{n}"
+    end
 
-  belongs_to :answerable, polymorphic: true
+    answerable_id 1
+    answerable_type 'Mock'
 
-  validates :name, presence: true
+    value 'foobar'
+    value_type :string
 
-  before_save :convert_value
+    trait :integer do
+      value 1
+      value_type :integer
+    end
+
+    trait :email do
+      value 'foo@bar.com'
+      value_type :email
+    end
+
+    trait :url do
+      value 'http://foobar.com'
+      value_type :url
+    end
+  end
 end

--- a/spec/factories/service_output.rb
+++ b/spec/factories/service_output.rb
@@ -1,0 +1,27 @@
+FactoryGirl.define do
+  factory :service_output do
+    sequence :name do |n|
+      "service_attribute_#{n}"
+    end
+
+    service
+
+    value 'foobar'
+    value_type :string
+
+    trait :integer do
+      value 1
+      value_type :integer
+    end
+
+    trait :email do
+      value 'foo@bar.com'
+      value_type :email
+    end
+
+    trait :url do
+      value 'http://foobar.com'
+      value_type :url
+    end
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,76 @@
+# == Schema Information
+#
+# Table name: answers
+#
+#  id              :integer          not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  answerable_id   :integer          not null
+#  answerable_type :string           not null
+#  name            :string           not null
+#  value           :text
+#  value_type      :integer
+#
+# Indexes
+#
+#  index_answers_on_answerable_type_and_answerable_id  (answerable_type,answerable_id)
+#
+
+require 'rails_helper'
+
+describe Answer do
+  it 'has a valid factory' do
+    expect(build(:answer)).to be_valid
+  end
+
+  it 'inherits from ValueTypes' do
+    expect(Answer.ancestors.include? ValueTypes).to be true
+  end
+
+  describe 'casting' do
+    it 'to strings' do
+      answer = create :answer, value: 'foobar'
+      answer.reload
+      expect(answer.value_type).to eq('string')
+      expect(answer.value).to eq('foobar')
+    end
+
+    it 'to numbers' do
+      answer = create :answer, :integer, value: 123
+      answer.reload
+      expect(answer.value_type).to eq('integer')
+      expect(answer.value).to eq(123)
+    end
+
+    it 'to emails' do
+      answer = create :answer, :email, value: 'foo@bar.com'
+      answer.reload
+      expect(answer.value_type).to eq('email')
+      expect(answer.value).to eq('foo@bar.com')
+    end
+
+    it 'to urls' do
+      answer = create :answer, :url, value: 'http://foobar.com'
+      answer.reload
+      expect(answer.value_type).to eq('url')
+      expect(answer.value).to eq('http://foobar.com')
+    end
+  end
+
+  describe 'cast failures thrown' do
+    it 'for integer' do
+      answer = build :answer, :integer, value: 'foo@bar.com'
+      expect { answer.save! }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Value is not a number')
+    end
+
+    it 'for emails' do
+      answer = build :answer, :email, value: '123 Main St.'
+      expect { answer.save! }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Value is not a valid e-mail address')
+    end
+
+    it 'for urls' do
+      answer = build :answer, :url, value: 123
+      expect { answer.save! }.to raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Value must be a valid URI')
+    end
+  end
+end

--- a/spec/models/service_output_spec.rb
+++ b/spec/models/service_output_spec.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: service_outputs
+#
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  service_id :integer          not null
+#  name       :string           not null
+#  value      :text
+#  value_type :integer
+#
+# Indexes
+#
+#  index_service_outputs_on_service_id  (service_id)
+#
+
+require 'rails_helper'
+
+describe ServiceOutput do
+  it 'has a valid factory' do
+    expect(build(:service_output)).to be_valid
+  end
+
+  it 'inherits from ValueTypes' do
+    expect(ServiceOutput.ancestors.include? ValueTypes).to be true
+  end
+
+  it 'can be added to services' do
+    service = create :service
+
+    service.service_outputs << build(:service_output)
+    service.service_outputs << build(:service_output, :integer)
+    service.service_outputs << build(:service_output, :email)
+
+    service.save
+    service.reload
+
+    expect(service.service_outputs.length).to eq(3)
+  end
+end


### PR DESCRIPTION
Services can record values into `.service_outputs`. The output can be typed and defaults to of type string.