### PR TITLE
Fixed save issues editing a  project and the back-to route

### DIFF
--- a/src/client/app/states/projects/edit/edit.html
+++ b/src/client/app/states/projects/edit/edit.html
@@ -1,1 +1,1 @@
-<project-form project="vm.project" heading="Edit A Project"></project-form>
+<project-form record="vm.project" heading="Edit A Project" back-to="projects.list"></project-form>


### PR DESCRIPTION
Resolves #942 

There's a new issue where you can't save an edited project after loading the page because the form-validation looks like it wants the "Maintenance Day" field to be in a data format of YYYY-MM-DD instead of YYYY-MM-DD HH:MM:SS (which is default). 

You can bypass this issue atm by clicking on the calendar and selecting a date to remove the timestamp

See: https://github.com/projectjellyfish/api/issues/981