### PR TITLE
Fixes maintenance day time bug

### DIFF
--- a/db/data/sample/projects.yml
+++ b/db/data/sample/projects.yml
@@ -17,7 +17,7 @@
     - question: cc
       value: GSM-4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'true'
       value_type: boolean
@@ -48,7 +48,7 @@
     - question: cc
       value: GSM-4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'true'
       value_type: boolean
@@ -82,7 +82,7 @@
     - question: cc
       value: BLG-4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'false'
       value_type: boolean
@@ -109,7 +109,7 @@
     - question: cc
       value: FIL-4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'true'
       value_type: boolean
@@ -136,7 +136,7 @@
     - question: cc
       value: CLD-4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'true'
       value_type: boolean
@@ -163,7 +163,7 @@
     - question: cc
       value: 4873849128497761
     - question: maint
-      value: 2015-05-20T05:00:00.000Z
+      value: 2015-05-20T00:00:00.000Z
     - question: do_maint
       value: 'true'
       value_type: boolean


### PR DESCRIPTION
<img width="1190" alt="screen shot 2015-10-26 at 4 05 50 pm" src="https://cloud.githubusercontent.com/assets/6640236/10740939/7d3b4fee-7bfb-11e5-92c3-905f61fa928a.png">
By modifying the projects seed, removing the time component from each maintenance day project question, editing projects will kickoff without a hitch.

Resolves: #982