### PR TITLE
Dynamic `order_questions`

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -42,15 +42,10 @@ class Product < ActiveRecord::Base
   scope :active, -> { where(active: true) }
 
   # TODO: Move contents of ProductType.order_questions here after removal of deprecated method
-  def order_questions
-    product_type.order_questions
-  end
+  delegate :order_questions, to: :product_type
 
   # TODO: Move contents of ProductType.service_class here after removal of deprecated method
-  def service_class
-    product_type.service_class
-  end
-
+  delegate :service_class, to: :product_type
 
   private
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,6 +16,7 @@
 #  cached_tag_list :string
 #  provider_id     :integer
 #  product_type_id :integer
+#  type            :string           default("Product"), not null
 #
 # Indexes
 #
@@ -39,6 +40,17 @@ class Product < ActiveRecord::Base
   after_initialize :init
 
   scope :active, -> { where(active: true) }
+
+  # TODO: Move contents of ProductType.order_questions here after removal of deprecated method
+  def order_questions
+    product_type.order_questions
+  end
+
+  # TODO: Move contents of ProductType.service_class here after removal of deprecated method
+  def service_class
+    product_type.service_class
+  end
+
 
   private
 

--- a/app/models/product_type.rb
+++ b/app/models/product_type.rb
@@ -56,10 +56,16 @@ class ProductType < ActiveRecord::Base
   end
 
   def order_questions
+    ActiveSupport::Deprecation.warn 'ProductType.order_questions will be removed in a future update, use Product.order_questions instead', caller
     []
   end
 
+  def product_class
+    'Product'.constantize
+  end
+
   def service_class
+    ActiveSupport::Deprecation.warn 'ProductType.service_class will be removed in a future update, use Product.service_class instead', caller
     'Service'.constantize
   end
 

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -16,6 +16,7 @@
 #  cached_tag_list :string
 #  provider_id     :integer
 #  product_type_id :integer
+#  type            :string           default("Product"), not null
 #
 # Indexes
 #
@@ -25,7 +26,7 @@
 #
 
 class ProductSerializer < ApplicationSerializer
-  attributes :id, :name, :description, :img, :active, :product_type_id
+  attributes :id, :name, :description, :img, :active, :product_type_id, :order_questions
   attributes :setup_price, :hourly_price, :monthly_price
   attributes :created_at, :updated_at, :deleted_at
   attribute :tag_list, key: :tags

--- a/app/serializers/product_type_serializer.rb
+++ b/app/serializers/product_type_serializer.rb
@@ -19,7 +19,7 @@
 #
 
 class ProductTypeSerializer < ApplicationSerializer
-  attributes :id, :type, :name, :provider, :description, :tags, :product_questions, :order_questions, :active
+  attributes :id, :type, :name, :provider, :description, :tags, :product_questions, :active
 
   def provider
     object.provider_type.split('::').last

--- a/app/use_cases/create_service_order.rb
+++ b/app/use_cases/create_service_order.rb
@@ -89,7 +89,7 @@ class CreateServiceOrder
   end
 
   def service_class
-    @service_class ||= product.product_type.service_class
+    @service_class ||= product.service_class
   end
 
   def service

--- a/db/migrate/20151022190245_add_type_to_products.rb
+++ b/db/migrate/20151022190245_add_type_to_products.rb
@@ -1,0 +1,5 @@
+class AddTypeToProducts < ActiveRecord::Migration
+  def change
+    add_column :products, :type, :string, default: 'Product', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151009194552) do
+ActiveRecord::Schema.define(version: 20151022190245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -252,7 +252,7 @@ ActiveRecord::Schema.define(version: 20151009194552) do
   add_index "product_types", ["uuid"], name: "index_product_types_on_uuid", using: :btree
 
   create_table "products", force: :cascade do |t|
-    t.string   "name",            limit: 255,                                         null: false
+    t.string   "name",            limit: 255,                                              null: false
     t.text     "description"
     t.boolean  "active",                                               default: true
     t.string   "img",             limit: 255
@@ -265,6 +265,7 @@ ActiveRecord::Schema.define(version: 20151009194552) do
     t.string   "cached_tag_list"
     t.integer  "provider_id"
     t.integer  "product_type_id"
+    t.string   "type",                                                 default: "Product", null: false
   end
 
   add_index "products", ["deleted_at"], name: "index_products_on_deleted_at", using: :btree

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -16,6 +16,7 @@
 #  cached_tag_list :string
 #  provider_id     :integer
 #  product_type_id :integer
+#  type            :string           default("Product"), not null
 #
 # Indexes
 #

--- a/spec/requests/products_spec.rb
+++ b/spec/requests/products_spec.rb
@@ -60,10 +60,9 @@ RSpec.describe 'Products API' do
   describe 'POST create' do
     it 'creates a product without any answers' do
       sign_in_as create :staff, :admin
-      product_attributes = attributes_for(
-        :product,
-        answers: nil
-      )
+      product_type = create :product_type
+      product_attributes = attributes_for :product, answers: nil
+      product_attributes[:product_type_id] = product_type.id
 
       post products_path, product_attributes
 
@@ -72,13 +71,13 @@ RSpec.describe 'Products API' do
 
     it 'maps provisioning_answers to a hash' do
       sign_in_as create :staff, :admin
-      product_attributes = attributes_for(
-        :product,
-        answers: [
-          { name: 'foo', value: 'bar', value_type: 'string' },
-          { name: 'fizz', value: 'buzz', value_type: 'string' }
-        ]
-      )
+      answers = [
+        { name: 'foo', value: 'bar', value_type: 'string' },
+        { name: 'fizz', value: 'buzz', value_type: 'string' }
+      ]
+      product_type = create :product_type
+      product_attributes = attributes_for :product, answers: answers
+      product_attributes[:product_type_id] = product_type.id
 
       post products_path, product_attributes
 

--- a/src/client/app/states/orders/create/create.state.js
+++ b/src/client/app/states/orders/create/create.state.js
@@ -56,7 +56,7 @@
     function initOrder() {
       vm.order = Order.new({product_id: product.id});
       vm.order.product_id = product.id;
-      vm.order.answers = product.product_type.order_questions;
+      vm.order.answers = product.order_questions;
     }
 
     function initForm() {


### PR DESCRIPTION
Move `order_questions` to `Product` to allow the questions to be be dependent on the
answers to `product_questions`. Product developers should create a custom `Product` class, which inherits from `::Product` to go along with the `ProductType` and `Service` classes they're already adding.

**BREAKING CHANGE**
- `ProductType`s should all now have a `product_class` which will return the custom product class for the product type
- `Product`s should include an `order_questions` method which returns what was previously returned in the `ProductType` class, and a `service_class` method which was also previously defined in the matching `ProductType`
- UX expects the `order_questions` to be returned on the products not on product types.

Deprecation warnings have been added to the `ProductType` methods and the two methods `order_questions`, and `service_class` will be removed in the next few weeks after the current list of extensions can be updated.

Resolves #979