### PR TITLE
Add a default policy for Products

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -47,6 +47,10 @@ class Product < ActiveRecord::Base
   # TODO: Move contents of ProductType.service_class here after removal of deprecated method
   delegate :service_class, to: :product_type
 
+  def self.policy_class
+    ProductPolicy
+  end
+
   private
 
   def init


### PR DESCRIPTION
Custom Product classes may define their own policy but will not have to with this new default.