### PR TITLE
Remove the `STATES` constant

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -32,8 +32,10 @@ class Alert < ActiveRecord::Base
   scope :alertable_type, ->(alertable_type) { where('alertable_type = ?', alertable_type) }
   scope :newest_first, -> { order('updated_at DESC') }
   scope :oldest_first, -> { order(:updated_at) }
+  scope :max_by_status, -> { order(%w(unknown ok pending warning critical).map { |s| "alerts.status = '#{s}'" }.join ', ').limit 1 }
 
   after_commit :cache_alert_data, on: [:create, :update]
+
   def cache_alert_data
     project.compute_current_status! if alertable == Project
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -54,7 +54,7 @@ class Project < ActiveRecord::Base
 
   def compute_current_status!
     if latest_service_alerts.any?
-      update(health: highest_priority_latest_alert.status.downcase)
+      update(health: latest_service_alerts.max_by_status.first.status.downcase)
     else
       update(health: 'ok')
     end
@@ -70,9 +70,5 @@ class Project < ActiveRecord::Base
 
   def problem_count
     latest_service_alerts.not_status('ok').count
-  end
-
-  def highest_priority_latest_alert
-    latest_service_alerts.max_by_status
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -69,7 +69,7 @@ class Project < ActiveRecord::Base
   end
 
   def problem_count
-    latest_service_alerts.not_status("ok").count
+    latest_service_alerts.not_status('ok').count
   end
 
   def highest_priority_latest_alert


### PR DESCRIPTION
`Project` no longer holds onto a list of state strings that are used for `Alert` states.

Also reworked some methods to use scopes from `Alert` or use a relationship on `Project`.

Resolves #964 