### PR TITLE
Adds UX for archiving projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -73,7 +73,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     authorize project
-    project.destroy
+    project.update archived: DateTime.now
     respond_with project
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -73,7 +73,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     authorize project
-    project.update archived: DateTime.now
+    project.update archived: DateTime.now.utc
     respond_with project
   end
 

--- a/src/client/app/components/project-memberships/project-memberships.directive.js
+++ b/src/client/app/components/project-memberships/project-memberships.directive.js
@@ -10,6 +10,7 @@
       restrict: 'AE',
       scope: {
         projectId: '=',
+        projectArchived: '=?',
         memberships: '='
       },
       link: link,

--- a/src/client/app/components/project-memberships/project-memberships.directive.js
+++ b/src/client/app/components/project-memberships/project-memberships.directive.js
@@ -1,4 +1,4 @@
-(function() {
+(function () {
   'use strict';
 
   angular.module('app.components')
@@ -9,8 +9,7 @@
     var directive = {
       restrict: 'AE',
       scope: {
-        projectId: '=',
-        projectArchived: '=?',
+        project: '=',
         memberships: '='
       },
       link: link,
@@ -33,6 +32,7 @@
       vm.activate = activate;
       vm.showModal = showModal;
       vm.remove = remove;
+      vm.archivedProject = archivedProject;
 
       function activate() {
       }
@@ -82,6 +82,10 @@
         function deleteFailure() {
           Toasts.error('Could not remove membership. Try again later.');
         }
+      }
+
+      function archivedProject() {
+        return null === vm.project.archived ? true : false;
       }
     }
   }

--- a/src/client/app/components/project-memberships/project-memberships.directive.js
+++ b/src/client/app/components/project-memberships/project-memberships.directive.js
@@ -1,4 +1,4 @@
-(function () {
+(function() {
   'use strict';
 
   angular.module('app.components')
@@ -32,7 +32,7 @@
       vm.activate = activate;
       vm.showModal = showModal;
       vm.remove = remove;
-      vm.archivedProject = projectArchiveCheck;
+      vm.readOnly = readOnlyCheck;
 
       function activate() {
       }
@@ -84,7 +84,7 @@
         }
       }
 
-      function projectArchiveCheck() {
+      function readOnlyCheck() {
         return null === vm.project.archived ? true : false;
       }
     }

--- a/src/client/app/components/project-memberships/project-memberships.directive.js
+++ b/src/client/app/components/project-memberships/project-memberships.directive.js
@@ -32,7 +32,7 @@
       vm.activate = activate;
       vm.showModal = showModal;
       vm.remove = remove;
-      vm.archivedProject = archivedProject;
+      vm.archivedProject = projectArchiveCheck;
 
       function activate() {
       }
@@ -84,7 +84,7 @@
         }
       }
 
-      function archivedProject() {
+      function projectArchiveCheck() {
         return null === vm.project.archived ? true : false;
       }
     }

--- a/src/client/app/components/project-memberships/project-memberships.directive.js
+++ b/src/client/app/components/project-memberships/project-memberships.directive.js
@@ -85,7 +85,7 @@
       }
 
       function readOnlyCheck() {
-        return null === vm.project.archived ? true : false;
+        return null === vm.project.archived;
       }
     }
   }

--- a/src/client/app/components/project-memberships/project-memberships.html
+++ b/src/client/app/components/project-memberships/project-memberships.html
@@ -1,6 +1,6 @@
 <region heading="Memberships">
   <div class="region__buttons">
-    <button type="button" class="btn-rounded btn-rounded--short" ng-if="::null === vm.projectArchived" ng-click="vm.showModal()">
+    <button ng-if="vm.archivedProject()" type="button" class="btn-rounded btn-rounded--short" ng-click="vm.showModal()">
       Add Membership
     </button>
   </div>
@@ -10,7 +10,7 @@
       <th class="tables__heading">Group</th>
       <th class="tables__heading">Role</th>
       <th class="tables__heading tables__heading--centered">Members</th>
-      <th class="tables__heading tables__heading--actions" ng-if="::null === vm.projectArchived">Action</th>
+      <th ng-if="vm.archivedProject()" nclass="tables__heading tables__heading--actions">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -19,10 +19,11 @@
       <td class="tables__cell">{{ row.role.name }}</td>
       <td class="tables__cell tables__cell--centered">{{ row.group.staff_count }}</td>
       <td class="tables__cell tables__cell--actions">
-        <a href="#" ng-click="vm.showModal(row)" class="tables__action" title="Edit" ng-if="::null === vm.projectArchived">
+        <a ng-if="vm.archivedProject()" href="#" ng-click="vm.showModal(row)" class="tables__action"
+           title="Edit">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>
-        <a href="#" class="tables__action" ng-if="::null === vm.projectArchived"
+        <a ng-if="vm.archivedProject()" href="#" class="tables__action"
            confirmation
            confirmation-position="left-center"
            confirmation-message="Are you sure you want to remove this membership?"

--- a/src/client/app/components/project-memberships/project-memberships.html
+++ b/src/client/app/components/project-memberships/project-memberships.html
@@ -1,6 +1,6 @@
 <region heading="Memberships">
   <div class="region__buttons">
-    <button ng-if="vm.archivedProject()" type="button" class="btn-rounded btn-rounded--short" ng-click="vm.showModal()">
+    <button ng-if="vm.readOnly()" type="button" class="btn-rounded btn-rounded--short" ng-click="vm.showModal()">
       Add Membership
     </button>
   </div>
@@ -10,7 +10,7 @@
       <th class="tables__heading">Group</th>
       <th class="tables__heading">Role</th>
       <th class="tables__heading tables__heading--centered">Members</th>
-      <th ng-if="vm.archivedProject()" nclass="tables__heading tables__heading--actions">Action</th>
+      <th ng-if="vm.readOnly()" nclass="tables__heading tables__heading--actions">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -23,7 +23,7 @@
            title="Edit">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>
-        <a ng-if="vm.archivedProject()" href="#" class="tables__action"
+        <a ng-if="vm.readOnly()" href="#" class="tables__action"
            confirmation
            confirmation-position="left-center"
            confirmation-message="Are you sure you want to remove this membership?"

--- a/src/client/app/components/project-memberships/project-memberships.html
+++ b/src/client/app/components/project-memberships/project-memberships.html
@@ -1,6 +1,6 @@
 <region heading="Memberships">
   <div class="region__buttons">
-    <button type="button" class="btn-rounded btn-rounded--short" ng-click="vm.showModal()">
+    <button type="button" class="btn-rounded btn-rounded--short" ng-if="::null === vm.projectArchived" ng-click="vm.showModal()">
       Add Membership
     </button>
   </div>
@@ -10,7 +10,7 @@
       <th class="tables__heading">Group</th>
       <th class="tables__heading">Role</th>
       <th class="tables__heading tables__heading--centered">Members</th>
-      <th class="tables__heading tables__heading--actions">Action</th>
+      <th class="tables__heading tables__heading--actions" ng-if="::null === vm.projectArchived">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -19,10 +19,10 @@
       <td class="tables__cell">{{ row.role.name }}</td>
       <td class="tables__cell tables__cell--centered">{{ row.group.staff_count }}</td>
       <td class="tables__cell tables__cell--actions">
-        <a href="#" ng-click="vm.showModal(row)" class="tables__action" title="Edit">
+        <a href="#" ng-click="vm.showModal(row)" class="tables__action" title="Edit" ng-if="::null === vm.projectArchived">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>
-        <a href="#" class="tables__action"
+        <a href="#" class="tables__action" ng-if="::null === vm.projectArchived"
            confirmation
            confirmation-position="left-center"
            confirmation-message="Are you sure you want to remove this membership?"

--- a/src/client/app/components/project-services/project-services.directive.js
+++ b/src/client/app/components/project-services/project-services.directive.js
@@ -36,7 +36,7 @@
       }
 
       function readOnlyCheck() {
-        return null === vm.project.archived ? true : false;
+        return null === vm.project.archived;
       }
     }
   }

--- a/src/client/app/components/project-services/project-services.directive.js
+++ b/src/client/app/components/project-services/project-services.directive.js
@@ -30,12 +30,12 @@
       var vm = this;
 
       vm.activate = activate;
-      vm.archivedProject = archivedProject;
+      vm.archivedProject = projectArchiveCheck;
 
       function activate() {
       }
 
-      function archivedProject() {
+      function projectArchiveCheck() {
         return null === vm.project.archived ? true : false;
       }
     }

--- a/src/client/app/components/project-services/project-services.directive.js
+++ b/src/client/app/components/project-services/project-services.directive.js
@@ -10,6 +10,7 @@
       restrict: 'AE',
       scope: {
         projectId: '=',
+        projectArchived: '=?',
         services: '='
       },
       link: link,

--- a/src/client/app/components/project-services/project-services.directive.js
+++ b/src/client/app/components/project-services/project-services.directive.js
@@ -9,8 +9,7 @@
     var directive = {
       restrict: 'AE',
       scope: {
-        projectId: '=',
-        projectArchived: '=?',
+        project: '=',
         services: '='
       },
       link: link,
@@ -31,8 +30,13 @@
       var vm = this;
 
       vm.activate = activate;
+      vm.archivedProject = archivedProject;
 
       function activate() {
+      }
+
+      function archivedProject() {
+        return null === vm.project.archived ? true : false;
       }
     }
   }

--- a/src/client/app/components/project-services/project-services.directive.js
+++ b/src/client/app/components/project-services/project-services.directive.js
@@ -30,12 +30,12 @@
       var vm = this;
 
       vm.activate = activate;
-      vm.archivedProject = projectArchiveCheck;
+      vm.readOnly = readOnlyCheck;
 
       function activate() {
       }
 
-      function projectArchiveCheck() {
+      function readOnlyCheck() {
         return null === vm.project.archived ? true : false;
       }
     }

--- a/src/client/app/components/project-services/project-services.html
+++ b/src/client/app/components/project-services/project-services.html
@@ -1,6 +1,6 @@
 <region heading="Services">
   <div class="region__buttons">
-    <button type="button" class="btn-rounded btn-rounded--short" ng-if="::null === vm.projectArchived " ui-sref="marketplace">
+    <button ng-if="vm.archivedProject()" type="button" class="btn-rounded btn-rounded--short" ui-sref="marketplace">
       Add Service
     </button>
   </div>
@@ -11,7 +11,7 @@
       <th class="tables__heading">Product</th>
       <th class="tables__heading tables__heading--centered tables__heading--status">Status</th>
       <th class="tables__heading tables__heading--centered tables__heading--health">Health</th>
-      <th class="tables__heading tables__heading--actions" ng-if="::null === vm.projectArchived">Action</th>
+      <th ng-if="vm.archivedProject()" class="tables__heading tables__heading--actions">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -23,10 +23,8 @@
         <status type="{{ :: row.health }}">{{ ::row.health }}</status>
       </td>
       <td class="tables__cell tables__cell--actions">
-        <a ui-sref="services.details({serviceId: row.id})"
-           class="tables__action"
-           title="Edit"
-           ng-if="::null === vm.projectArchived">
+        <a ng-if="vm.archivedProject()" ui-sref="services.details({serviceId: row.id})" class="tables__action"
+           title="Edit">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>
       </td>

--- a/src/client/app/components/project-services/project-services.html
+++ b/src/client/app/components/project-services/project-services.html
@@ -1,6 +1,6 @@
 <region heading="Services">
   <div class="region__buttons">
-    <button type="button" class="btn-rounded btn-rounded--short" ui-sref="marketplace">
+    <button type="button" class="btn-rounded btn-rounded--short" ng-if="::null === vm.projectArchived " ui-sref="marketplace">
       Add Service
     </button>
   </div>
@@ -11,7 +11,7 @@
       <th class="tables__heading">Product</th>
       <th class="tables__heading tables__heading--centered tables__heading--status">Status</th>
       <th class="tables__heading tables__heading--centered tables__heading--health">Health</th>
-      <th class="tables__heading tables__heading--actions">Action</th>
+      <th class="tables__heading tables__heading--actions" ng-if="::null === vm.projectArchived">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -23,7 +23,10 @@
         <status type="{{ :: row.health }}">{{ ::row.health }}</status>
       </td>
       <td class="tables__cell tables__cell--actions">
-        <a ui-sref="services.details({serviceId: row.id})" class="tables__action" title="Edit">
+        <a ui-sref="services.details({serviceId: row.id})"
+           class="tables__action"
+           title="Edit"
+           ng-if="::null === vm.projectArchived">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>
       </td>

--- a/src/client/app/components/project-services/project-services.html
+++ b/src/client/app/components/project-services/project-services.html
@@ -1,6 +1,6 @@
 <region heading="Services">
   <div class="region__buttons">
-    <button ng-if="vm.archivedProject()" type="button" class="btn-rounded btn-rounded--short" ui-sref="marketplace">
+    <button ng-if="vm.readOnly()" type="button" class="btn-rounded btn-rounded--short" ui-sref="marketplace">
       Add Service
     </button>
   </div>
@@ -11,7 +11,7 @@
       <th class="tables__heading">Product</th>
       <th class="tables__heading tables__heading--centered tables__heading--status">Status</th>
       <th class="tables__heading tables__heading--centered tables__heading--health">Health</th>
-      <th ng-if="vm.archivedProject()" class="tables__heading tables__heading--actions">Action</th>
+      <th ng-if="vm.readOnly()" class="tables__heading tables__heading--actions">Action</th>
     </tr>
     </thead>
     <tbody>
@@ -23,7 +23,7 @@
         <status type="{{ :: row.health }}">{{ ::row.health }}</status>
       </td>
       <td class="tables__cell tables__cell--actions">
-        <a ng-if="vm.archivedProject()" ui-sref="services.details({serviceId: row.id})" class="tables__action"
+        <a ng-if="vm.readOnly()" ui-sref="services.details({serviceId: row.id})" class="tables__action"
            title="Edit">
           <img src="/images/ic_edit.png" alt="Edit"/>
         </a>

--- a/src/client/app/states/projects/details/details.html
+++ b/src/client/app/states/projects/details/details.html
@@ -6,18 +6,18 @@
     <span class="content-header__title">{{ ::vm.project.name }}</span>
   </div>
   <div class="content-header__aside">
-    <div class="btn-group" role="group">
-      <button class="btn-rounded" ari-label="archive" ng-disabled="vm.activeServices()"
-              ng-if="::null === vm.project.archived"
-              confirmation
-              confirmation-message="Would you like to archive this project?"
-              confirmation-ok-style="primary"
-              confirmation-ok-text="Archive"
-              confirmation-on-ok="vm.archiveProject()"
-              confirmation-show-cancel="true">Archive
-      </button>
-      <a ng-if="::null === vm.project.archived && 'approved' === vm.project.status" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
-    </div>
+    <button ng-if="::null === vm.project.archived" class="btn-rounded" ari-label="archive"
+            ng-disabled="vm.activeServices()"
+            confirmation
+            confirmation-position="bottom"
+            confirmation-message="Would you like to archive this project?"
+            confirmation-ok-style="primary"
+            confirmation-ok-text="Archive"
+            confirmation-on-ok="vm.archiveProject()"
+            confirmation-show-cancel="true">Archive
+    </button>
+    <a ng-if="::null === vm.project.archived && 'approved' === vm.project.status"
+       ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
   </div>
 </content-header>
 
@@ -104,12 +104,12 @@
 </details-table>
 
 <!-- Services -->
-<project-services ng-if="::'approved' === vm.project.status" project-archived="vm.project.archived" project-id="vm.project.id"
-                  services="vm.services"></project-services>
+<project-services ng-if="::'approved' === vm.project.status" project="vm.project" services="vm.services">
+</project-services>
 
 <!-- Memberships -->
-<project-memberships ng-if="::'approved' === vm.project.status" project-archived="vm.project.archived" project-id="vm.project.id"
-                     memberships="vm.memberships"></project-memberships>
+<project-memberships ng-if="::'approved' === vm.project.status" project="vm.project" memberships="vm.memberships">
+</project-memberships>
 
 <!--Project Answers-->
 <region heading="Project Specifications">

--- a/src/client/app/states/projects/details/details.html
+++ b/src/client/app/states/projects/details/details.html
@@ -16,7 +16,7 @@
               confirmation-on-ok="vm.archiveProject()"
               confirmation-show-cancel="true">Archive
       </button>
-      <a  ng-if="::'approved' === vm.project.status" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
+      <a ng-if="::'approved' === vm.project.status || ::null === vm.project.archived" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
     </div>
   </div>
 </content-header>

--- a/src/client/app/states/projects/details/details.html
+++ b/src/client/app/states/projects/details/details.html
@@ -5,8 +5,19 @@
     <div ng-if="::!vm.project.img" class="project-details__icon project-details__icon--missing"></div>
     <span class="content-header__title">{{ ::vm.project.name }}</span>
   </div>
-  <div ng-if="::'approved' === vm.project.status" class="content-header__aside">
-    <a ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded">Edit Project</a>
+  <div class="content-header__aside">
+    <div class="btn-group" role="group">
+      <button class="btn-rounded" ari-label="archive" ng-disabled="vm.activeServices()"
+              ng-if="::null === vm.project.archived"
+              confirmation
+              confirmation-message="Would you like to archive this project?"
+              confirmation-ok-style="primary"
+              confirmation-ok-text="Archive"
+              confirmation-on-ok="vm.archiveProject()"
+              confirmation-show-cancel="true">Archive
+      </button>
+      <a  ng-if="::'approved' === vm.project.status" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
+    </div>
   </div>
 </content-header>
 
@@ -93,11 +104,11 @@
 </details-table>
 
 <!-- Services -->
-<project-services ng-if="::'approved' === vm.project.status" project-id="vm.project.id"
+<project-services ng-if="::'approved' === vm.project.status" project-archived="vm.project.archived" project-id="vm.project.id"
                   services="vm.services"></project-services>
 
 <!-- Memberships -->
-<project-memberships ng-if="::'approved' === vm.project.status" project-id="vm.project.id"
+<project-memberships ng-if="::'approved' === vm.project.status" project-archived="vm.project.archived" project-id="vm.project.id"
                      memberships="vm.memberships"></project-memberships>
 
 <!--Project Answers-->

--- a/src/client/app/states/projects/details/details.html
+++ b/src/client/app/states/projects/details/details.html
@@ -16,7 +16,7 @@
               confirmation-on-ok="vm.archiveProject()"
               confirmation-show-cancel="true">Archive
       </button>
-      <a ng-if="::'approved' === vm.project.status || ::null === vm.project.archived" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
+      <a ng-if="::null === vm.project.archived && 'approved' === vm.project.status" ui-sref="projects.edit({projectId: vm.project.id})" class="btn-rounded" ari-label="edit">Edit</a>
     </div>
   </div>
 </content-header>

--- a/src/client/app/states/projects/details/details.state.js
+++ b/src/client/app/states/projects/details/details.state.js
@@ -110,18 +110,6 @@
       var status = lodash.pluck(vm.services, 'status');
       if (0 === status.length) {
         return false;
-      } else {
-        for (var i = 0; i <= status.length; i++) {
-          switch (status[i]) {
-            case 'stopped':
-            case 'unavailable':
-            case 'retired':
-            case 'terminated':
-              break;
-            default:
-              return true;
-          }
-        }
       }
     }
 

--- a/src/client/app/states/projects/list/list.html
+++ b/src/client/app/states/projects/list/list.html
@@ -25,7 +25,7 @@
   </tr>
   </thead>
   <tbody>
-  <tr ng-repeat="row in vm.projects track by row.id">
+  <tr ng-repeat="row in vm.projects track by row.id" ng-if="null === row.archived ">
     <td class="tables__cell tables__cell--description">
       <project-description project="row" link-to="projects.details({projectId: {{row.id}}})"></project-description>
     </td>
@@ -43,7 +43,47 @@
   </tr>
   </tbody>
 </table>
-
+<hr/>
+<region heading="Achieved Projects"  ng-if="::vm.projectsArchived.length > 1">
+    <table st-table="vm.projects" class="tables tables--bordered">
+      <thead>
+      <tr>
+        <th st-sort="name" class="tables__heading tables__heading--sortable">Project</th>
+        <th st-sort="approval"
+            class="tables__heading tables__heading--centered tables__heading--sortable projects-list__approval">
+          Approved
+        </th>
+        <th st-sort="health"
+            class="tables__heading tables__heading--centered tables__heading--health tables__heading--sortable">
+          Health
+        </th>
+        <th st-sort="budget" class="tables__heading tables__heading--sortable projects-list__budget">Budget</th>
+        <th st-sort="spent" class="tables__heading tables__heading--sortable projects-list__spent">Spent</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr ng-repeat="row in vm.projects track by row.id" ng-if="null !== row.archived ">
+        <td class="tables__cell tables__cell--description">
+          <project-description project="row" link-to="projects.details({projectId: {{row.id}}})"></project-description>
+        </td>
+        <td class="tables__cell tables__cell--centered">
+          <img ng-if="::'approved' === row.status" src="/images/ic_required.png" alt="Approved"
+               title="Project is approved"/>
+          <img ng-if="::'rejected' === row.status" src="/images/ic_deletequestion.png" alt="Rejected"
+               title="Project is rejected"/>
+        </td>
+        <td class="tables__cell tables__cell--centered">
+          <status type="{{ ::row.health }}">{{ ::row.health }}</status>
+        </td>
+        <td class="tables__cell tables__cell--budget">{{ ::row.budget | currency }}</td>
+        <td class="tables__cell tables__cell--spent">{{ ::row.spent | currency }}</td>
+      </tr>
+      </tbody>
+    </table>
+  <div ng-if="::0 === vm.projects.length" class="tables__empty">
+    No archived projects at this time.
+  </div>
+</region>
 
 
 

--- a/src/client/app/states/projects/list/list.html
+++ b/src/client/app/states/projects/list/list.html
@@ -25,7 +25,7 @@
   </tr>
   </thead>
   <tbody>
-  <tr ng-repeat="row in vm.projects track by row.id" ng-if="null === row.archived ">
+  <tr ng-if="null === row.archived" ng-repeat="row in vm.projects track by row.id">
     <td class="tables__cell tables__cell--description">
       <project-description project="row" link-to="projects.details({projectId: {{row.id}}})"></project-description>
     </td>
@@ -44,7 +44,7 @@
   </tbody>
 </table>
 <hr/>
-<region heading="Achieved Projects"  ng-if="::vm.projectsArchived.length > 1">
+<region ng-if="::vm.projectsArchived.length > 1" heading="Archived Projects">
     <table st-table="vm.projects" class="tables tables--bordered">
       <thead>
       <tr>

--- a/src/client/app/states/projects/list/list.html
+++ b/src/client/app/states/projects/list/list.html
@@ -25,7 +25,7 @@
   </tr>
   </thead>
   <tbody>
-  <tr ng-if="null === row.archived" ng-repeat="row in vm.projects track by row.id">
+  <tr ng-repeat="row in vm.projects track by row.id">
     <td class="tables__cell tables__cell--description">
       <project-description project="row" link-to="projects.details({projectId: {{row.id}}})"></project-description>
     </td>
@@ -44,8 +44,8 @@
   </tbody>
 </table>
 <hr/>
-<region ng-if="::vm.projectsArchived.length > 1" heading="Archived Projects">
-    <table st-table="vm.projects" class="tables tables--bordered">
+<region ng-if="::vm.archivedProjects.length >= 1" heading="Archived Projects">
+    <table st-table="vm.projects" class="tables">
       <thead>
       <tr>
         <th st-sort="name" class="tables__heading tables__heading--sortable">Project</th>
@@ -62,7 +62,7 @@
       </tr>
       </thead>
       <tbody>
-      <tr ng-repeat="row in vm.projects track by row.id" ng-if="null !== row.archived ">
+      <tr ng-repeat="row in vm.archivedProjects track by row.id">
         <td class="tables__cell tables__cell--description">
           <project-description project="row" link-to="projects.details({projectId: {{row.id}}})"></project-description>
         </td>
@@ -80,9 +80,6 @@
       </tr>
       </tbody>
     </table>
-  <div ng-if="::0 === vm.projects.length" class="tables__empty">
-    No archived projects at this time.
-  </div>
 </region>
 
 

--- a/src/client/app/states/projects/list/list.state.js
+++ b/src/client/app/states/projects/list/list.state.js
@@ -36,6 +36,7 @@
     vm.projects = projects;
     vm.activate = activate;
     vm.title = 'Projects';
+    vm.projectsArchived = lodash.uniq(lodash.pluck(vm.projects, 'archived'));
 
     activate();
 

--- a/src/client/app/states/projects/list/list.state.js
+++ b/src/client/app/states/projects/list/list.state.js
@@ -32,11 +32,11 @@
   /** @ngInject */
   function StateController(projects, lodash) {
     var vm = this;
-
-    vm.projects = projects;
+    var allProjects = lodash.partition(projects, {'archived': null});
+    vm.projects = allProjects[0];
     vm.activate = activate;
     vm.title = 'Projects';
-    vm.projectsArchived = lodash.uniq(lodash.pluck(vm.projects, 'archived'));
+    vm.archivedProjects = allProjects[1];
 
     activate();
 


### PR DESCRIPTION
<img width="1920" alt="screen shot 2015-11-03 at 8 04 41 am" src="https://cloud.githubusercontent.com/assets/6640236/10908709/8fec7ee0-8201-11e5-8500-068deeebe4cc.png">
<img width="1920" alt="screen shot 2015-11-03 at 8 02 46 am" src="https://cloud.githubusercontent.com/assets/6640236/10908707/8febd09e-8201-11e5-826d-c187155e241b.png">
<img width="1920" alt="screen shot 2015-11-03 at 8 03 06 am" src="https://cloud.githubusercontent.com/assets/6640236/10908710/8feceac4-8201-11e5-96e4-bc8d5c6549f3.png">
<img width="1920" alt="screen shot 2015-11-03 at 8 02 39 am" src="https://cloud.githubusercontent.com/assets/6640236/10908708/8febe688-8201-11e5-8d86-60571866cbca.png">








Converts the "Edit" button to a group now including "Archive", said button is disabled when a project has services that are active.
Hijacks the delete project action to act as archive (rather than delete).
Updates relevant directives on the project.details state to suppress actions when a project is archived.

Items of additional note: 
* archived table doesn't show till there's cause
* confirmation modal gets wacky due to the source button being placed in the upper right, on the agenda, another pr to revert confirmation modal to be centered

closes #935