### PR TITLE
Fix counter_cache deprecation issue

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,6 +13,6 @@
 class Group < ActiveRecord::Base
   has_many :memberships
   has_many :projects, through: :memberships
-  has_many :groups_staff, counter_cache: :staff_count
-  has_many :staff, through: :groups_staff
+  has_many :groups_staff
+  has_many :staff, through: :groups_staff, dependent: :destroy
 end

--- a/app/models/groups_staff.rb
+++ b/app/models/groups_staff.rb
@@ -18,5 +18,5 @@ class GroupsStaff < ActiveRecord::Base
   self.table_name = 'groups_staff'
 
   belongs_to :staff
-  belongs_to :group
+  belongs_to :group, counter_cache: :staff_count
 end


### PR DESCRIPTION
Closes #943
The counter_cache needs to be declared as part of the belongs_to association
dependent: :destroy fixes an issue where API DELETE destroy did not decrement staff_count.