### PR TITLE
Edited the install guide links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ To see a detailed list of [System Requirements](https://github.com/projectjellyf
 
 Jellyfish is a Ruby on Rails application.  Please choose the appropriate installation guide for your system:
 
-* Mac Users: [INSTALL-OSX.md](https://github.com/projectjellyfish/api/blob/master/docs/INSTALL-OSX.md) - Mac OS Installation (generally used for development)
+* Mac Users: [INSTALL-OSX.md](https://github.com/projectjellyfish/api/blob/master/docs/install-guides/mac.md) - Mac OS Installation (generally used for development)
 
-* Windows Users: [INSTALL-RHEL.md](https://github.com/projectjellyfish/api/blob/master/docs/INSTALL-RHEL.md)  - Red Hat Enterprise Linux / CentOS installation
+* Windows Users: [INSTALL-RHEL.md](https://github.com/projectjellyfish/api/blob/master/docs/install-guides/rhel.md)  - Red Hat Enterprise Linux / CentOS installation
 
 * Heroku Quick Install: 
 


### PR DESCRIPTION
The README's install guide links were producing 404 errors due to file name changes that had occurred. This fix should correct the errors to be functional pages. 