### PR TITLE
Resolve 302 return on staff relogin 

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < Devise::SessionsController
   respond_to :json, :html
 
-  skip_before_action :require_user, only: :create
+  skip_before_action :require_no_authentication, only: :create
   skip_before_action :verify_signed_out_user, only: :destroy
   # before_action :pre_hook
   # after_action :post_hook


### PR DESCRIPTION
If on the login state and already logged in, posting credentials returns a 302. Documentation for $http states "A response status code between 200 and 299 is considered a success status and will result in the success callback being called."

No image necessary as no views modified.

closes #939