### PR TITLE
Resolves IE9 date picker not closing upon selection

### DIFF
--- a/src/client/app/components/forms/formly.config.js
+++ b/src/client/app/components/forms/formly.config.js
@@ -205,8 +205,7 @@
               showWeeks: false
             }
           }
-        },
-        controller: DateFieldController
+        }
       });
 
       function attributer(attr) {
@@ -215,11 +214,6 @@
 
       function binder(binding) {
         ngModelAttrs[lodash.camelCase(binding)] = {bound: binding};
-      }
-
-      function DateFieldController($scope) {
-        $scope.datepicker = $scope.datepicker || {};
-        $scope.datepicker.opened = false;
       }
     }
 

--- a/src/client/app/components/forms/formly.config.js
+++ b/src/client/app/components/forms/formly.config.js
@@ -198,9 +198,6 @@
         defaultOptions: {
           ngModelAttrs: ngModelAttrs,
           templateOptions: {
-            onFocus: function($viewValue, $modelValue, scope) {
-              scope.to.isOpen = !scope.to.isOpen;
-            },
             datepickerPopup: 'yyyy-MM-dd',
             datepickerOptions: {
               formatYear: 'yy',
@@ -208,7 +205,8 @@
               showWeeks: false
             }
           }
-        }
+        },
+        controller: DateFieldController
       });
 
       function attributer(attr) {
@@ -217,6 +215,11 @@
 
       function binder(binding) {
         ngModelAttrs[lodash.camelCase(binding)] = {bound: binding};
+      }
+
+      function DateFieldController($scope) {
+        $scope.datepicker = $scope.datepicker || {};
+        $scope.datepicker.opened = false;
       }
     }
 

--- a/src/client/app/components/forms/types/date.html
+++ b/src/client/app/components/forms/types/date.html
@@ -1,11 +1,9 @@
 <div class="input-group">
   <span class="input-group-btn">
-    <button type="button" class="btn btn-default field__group-button" ng-click="datepicker.opened = !datepicker.opened;">
+    <button type="button" class="btn btn-default field__group-button" ng-click="datepicker.opened = !datepicker.opened">
       <i class="fa fa-calendar"></i>
     </button>
   </span>
-  <input type="text" class="field__input" ng-model="model[options.key]"
-         ng-click="datepicker.opened = !datepicker.opened;"
-         is-open="datepicker.opened"
-         datepicker-options="to.datepickerOptions"/>
+  <input class="field__input" ng-model="model[options.key]" is-open="datepicker.opened"
+         datepicker-options="to.datepickerOptions" ng-click="datepicker.opened= !datepicker.opened"/>
 </div>

--- a/src/client/app/components/forms/types/date.html
+++ b/src/client/app/components/forms/types/date.html
@@ -1,9 +1,11 @@
 <div class="input-group">
   <span class="input-group-btn">
-    <button type="button" class="btn btn-default field__group-button" ng-click="to.isOpen = !to.isOpen">
+    <button type="button" class="btn btn-default field__group-button" ng-click="datepicker.opened = !datepicker.opened;">
       <i class="fa fa-calendar"></i>
     </button>
   </span>
-  <input class="field__input" ng-model="model[options.key]" is-open="to.isOpen"
+  <input type="text" class="field__input" ng-model="model[options.key]"
+         ng-click="datepicker.opened = !datepicker.opened;"
+         is-open="datepicker.opened"
          datepicker-options="to.datepickerOptions"/>
 </div>


### PR DESCRIPTION
Previous behavior, from IE9, date picker would not close when a date was selected, rather only when the input field was selected.  This adjustment makes the calendar icon and input field a toggle for the picker dropdown and ensures the dropdown closes when the a date is selected from the dropdown for all browsers.

Image not included as this pr includes no cosmetic changes.

closes #1053 