### PR TITLE
Update the internal structure of the formly questions field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "highcharts-ng": "~0.0.8",
     "angular-formly": "~7.1.0",
     "angular-marked": "~0.0.21",
-    "angular-aria": "~1.4.8"
+    "angular-aria": "~1.4.0"
   },
   "resolutions": {
     "angular": "~1.4.0"


### PR DESCRIPTION
The questions field was using a model for each generated internal field. This made
it very difficult to create dependencies between fields.

The generated fields now use a shared model that lives in the generated form. The
parent model is made available on the new shared model at `$parent`.

 This only modifies the internal structure of the question fields data. The structure
 of the model and the structure of the data sent to the server remain unchanged.

 - Made the `angular-aria` version number match the other `angular-*` packages

@mafernando 