### PR TITLE
Update jellyfish-aws gem to point to master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,6 @@ gem 'activesupport-json_encoder'
 gem 'has_scope'
 
 # Jellyfish Extensions
-gem 'jellyfish-aws', git: 'git://github.com/projectjellyfish/jellyfish-aws.git', branch: 'develop'
+gem 'jellyfish-aws', git: 'git://github.com/projectjellyfish/jellyfish-aws.git'
 gem 'jellyfish-docker', git: 'git://github.com/projectjellyfish/jellyfish-docker.git'
 gem 'jellyfish-azure', git: 'git://github.com/neudesic/jellyfish-azure.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/projectjellyfish/jellyfish-aws.git
-  revision: 604bc3e57f4a8f0507fb910258be069cb0444f0a
-  branch: develop
+  revision: 7ee30ae7399593cef5e2420d9f8538cdb56f7f33
   specs:
     jellyfish-aws (0.0.8)
       bcrypt (~> 3.1)


### PR DESCRIPTION
Points jellyfish-aws gem to master and adds back S3 and RDS alongside EC2.